### PR TITLE
Export `path` and `copy_options` from cfs on Linux

### DIFF
--- a/libwololokingdoms/caseless.h
+++ b/libwololokingdoms/caseless.h
@@ -65,58 +65,56 @@ static const fs::path& caseless(fs::path const& input) {
  * systems.
  */
 namespace cfs {
-static fs::path resolve [[maybe_unused]] (const fs::path& p) {
-  return caseless(p);
-}
-static bool exists [[maybe_unused]] (const fs::path& p) {
+using path = fs::path;
+using copy_options = fs::copy_options;
+static path resolve [[maybe_unused]] (const path& p) { return caseless(p); }
+static bool exists [[maybe_unused]] (const path& p) {
   return fs::exists(caseless(p));
 }
-static bool is_directory [[maybe_unused]] (const fs::path& p) {
+static bool is_directory [[maybe_unused]] (const path& p) {
   return fs::is_directory(caseless(p));
 }
-static bool is_symlink [[maybe_unused]] (const fs::path& p) {
+static bool is_symlink [[maybe_unused]] (const path& p) {
   return fs::is_symlink(caseless(p));
 }
-static bool is_empty [[maybe_unused]] (const fs::path& p) {
+static bool is_empty [[maybe_unused]] (const path& p) {
   return fs::is_empty(caseless(p));
 }
-static bool equivalent [[maybe_unused]] (const fs::path& a, const fs::path& b) {
+static bool equivalent [[maybe_unused]] (const path& a, const path& b) {
   return fs::equivalent(caseless(a), caseless(b));
 }
-static void remove [[maybe_unused]] (const fs::path& p) {
-  fs::remove(caseless(p));
-}
-static void remove_all [[maybe_unused]] (const fs::path& p) {
+static void remove [[maybe_unused]] (const path& p) { fs::remove(caseless(p)); }
+static void remove_all [[maybe_unused]] (const path& p) {
   fs::remove_all(caseless(p));
 }
-static void create_directory [[maybe_unused]] (const fs::path& p) {
+static void create_directory [[maybe_unused]] (const path& p) {
   fs::create_directory(caseless(p));
 }
-static void create_directories [[maybe_unused]] (const fs::path& p) {
+static void create_directories [[maybe_unused]] (const path& p) {
   fs::create_directories(caseless(p));
 }
-static void copy_file [[maybe_unused]] (const fs::path& a, const fs::path& b) {
+static void copy_file [[maybe_unused]] (const path& a, const path& b) {
   fs::copy_file(caseless(a), caseless(b));
 }
-static void copy_file [[maybe_unused]] (const fs::path& a, const fs::path& b,
-                                        std::error_code& ec) {
+static void copy_file
+    [[maybe_unused]] (const path& a, const path& b, std::error_code& ec) {
   fs::copy_file(caseless(a), caseless(b), ec);
 }
-static void copy_file [[maybe_unused]] (const fs::path& a, const fs::path& b,
-                                        fs::copy_options options) {
+static void copy_file
+    [[maybe_unused]] (const path& a, const path& b, copy_options options) {
   fs::copy_file(caseless(a), caseless(b), options);
 }
-static void copy [[maybe_unused]] (const fs::path& a, const fs::path& b,
-                                   fs::copy_options options) {
+static void copy
+    [[maybe_unused]] (const path& a, const path& b, copy_options options) {
   fs::copy(caseless(a), caseless(b), options);
 }
-static void rename [[maybe_unused]] (const fs::path& a, const fs::path& b) {
+static void rename [[maybe_unused]] (const path& a, const path& b) {
   fs::rename(caseless(a), caseless(b));
 }
-static size_t file_size [[maybe_unused]] (const fs::path& p) {
+static size_t file_size [[maybe_unused]] (const path& p) {
   return fs::file_size(caseless(p));
 }
-static fs::file_time_type last_write_time [[maybe_unused]] (const fs::path& p) {
+static fs::file_time_type last_write_time [[maybe_unused]] (const path& p) {
   return fs::last_write_time(caseless(p));
 }
 } // namespace cfs

--- a/libwololokingdoms/wkconverter.cpp
+++ b/libwololokingdoms/wkconverter.cpp
@@ -1140,14 +1140,14 @@ void WKConverter::transferHdDatElements(genie::DatFile* hdDat,
   terrainSwap(hdDat, aocDat, 41, 50, 15013); // acacia forest
   terrainSwap(hdDat, aocDat, 16, 49, 15025); // baobab forest
 
-  std::map<int, std::string> newTerrainSlps = {
+  const std::array<std::tuple<int, std::string>, 7> newTerrainSlps = {{
       {15012, "DLC_MANGROVEFOREST.slp"},
       {15013, "ACACIA_FOREST.slp"},
       {15025, "BAOBAB.slp"},
       {15003, "15003.slp"},
       {15032, "CRACKEDIT.slp"},
       {15034, "ICE_SOLID.slp"},
-      {15020, "ICE_BEACH.slp"}};
+      {15020, "ICE_BEACH.slp"}}};
 
   for (auto& [id, name] : newTerrainSlps) {
     if (slpFiles[id].empty())


### PR DESCRIPTION
A recent commit added some uses of `cfs::copy_options`, but that didn't exist in the caseless fs implementation for Linux. I had used `fs::copy_options` everywhere and only used `cfs::` for the methods that needed it, but in hindsight it'd be better to make the `cfs::` namespace compatible with `fs::` as much as is necessary, so there is no difference between OSes. This is a start that fixes the build on Linux :)