### PR TITLE
Apply clang-tidy autofixes, optimize some regexes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+---
+Checks: 'bugprone-*,clang-diagnostic-*,clang-analyzer-*,modernize-*,-modernize-use-trailing-return-type,portability-*,readability-*,-readability-braces-around-statements,-readability-uppercase-literal-suffix'
+FormatStyle: file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,3 @@
 ---
-Checks: 'bugprone-*,clang-diagnostic-*,clang-analyzer-*,modernize-*,-modernize-use-trailing-return-type,portability-*,readability-*,-readability-braces-around-statements,-readability-uppercase-literal-suffix'
+Checks: 'bugprone-*,clang-diagnostic-*,clang-analyzer-*,modernize-*,-modernize-use-trailing-return-type,portability-*,readability-*,-readability-braces-around-statements,-readability-magic-numbers,-readability-uppercase-literal-suffix'
 FormatStyle: file

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "libwololokingdoms/third_party/filesystem"]
 	path = libwololokingdoms/third_party/filesystem
 	url = https://github.com/gulrak/filesystem
+[submodule "libwololokingdoms/third_party/compile-time-regular-expressions"]
+	path = libwololokingdoms/third_party/compile-time-regular-expressions
+	url = https://github.com/hanickadot/compile-time-regular-expressions

--- a/dialog.h
+++ b/dialog.h
@@ -9,9 +9,9 @@ class Dialog : public QDialog {
   Q_OBJECT
 
 public:
-  explicit Dialog(QWidget* parent = 0, QString message = "Error",
+  explicit Dialog(QWidget* parent = nullptr, QString message = "Error",
                   QString title = "Note");
-  ~Dialog();
+  ~Dialog() override;
 
 private:
   Ui::Dialog* ui;

--- a/libwololokingdoms/CMakeLists.txt
+++ b/libwololokingdoms/CMakeLists.txt
@@ -29,6 +29,7 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third_party/genieutils/)
 # include directories:
 
 include_directories(include/)
+include_directories(third_party/compile-time-regular-expressions/include/)
 include_directories(third_party/genieutils/include/)
 include_directories(third_party/miniz)
 if (WIN32)
@@ -58,6 +59,8 @@ if (NOT WORKING_STD_FS)
 endif()
 
 if (WIN32)
+  add_definitions(-DWIN32_LEAN_AND_MEAN)
+  add_definitions(-DNOMINMAX)
   add_definitions(-DUNICODE)
   add_definitions(-D_UNICODE)
 endif()

--- a/libwololokingdoms/base64.cpp
+++ b/libwololokingdoms/base64.cpp
@@ -13,8 +13,10 @@ static const unsigned char base64_table[65] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 std::string base64_encode(const unsigned char* src, size_t len) {
-  unsigned char *out, *pos;
-  const unsigned char *end, *in;
+  unsigned char* out;
+  unsigned char* pos;
+  const unsigned char* end;
+  const unsigned char* in;
 
   size_t olen;
 
@@ -38,7 +40,7 @@ std::string base64_encode(const unsigned char* src, size_t len) {
     in += 3;
   }
 
-  if (end - in) {
+  if ((end - in) != 0) {
     *pos++ = base64_table[in[0] >> 2];
     if (end - in == 1) {
       *pos++ = base64_table[(in[0] & 0x03) << 4];

--- a/libwololokingdoms/drs_creator.cpp
+++ b/libwololokingdoms/drs_creator.cpp
@@ -13,7 +13,7 @@ inline void DRSCreatorTableEntry::writeMeta(std::ostream& target) {
 
 inline void DRSCreatorTableEntry::writeContent(std::ostream& target) {
   offset_ = target.tellp();
-  if (stream_) {
+  if (stream_ != nullptr) {
     target << stream_->rdbuf();
   } else {
     std::ifstream stream(filename_, std::ios::binary);

--- a/libwololokingdoms/drs_creator.h
+++ b/libwololokingdoms/drs_creator.h
@@ -37,7 +37,7 @@ public:
   DRSCreatorTableEntry& operator=(DRSCreatorTableEntry const&);
   inline ~DRSCreatorTableEntry() {
     // may be moved out.
-    if (stream_)
+    if (stream_ != nullptr)
       delete stream_;
   }
 

--- a/libwololokingdoms/drs_creator.h
+++ b/libwololokingdoms/drs_creator.h
@@ -2,6 +2,7 @@
 #include <fs.h>
 #include <iostream>
 #include <map>
+#include <utility>
 #include <vector>
 
 enum class DRSTableType {
@@ -25,8 +26,8 @@ class DRSCreatorTableEntry {
 public:
   inline DRSCreatorTableEntry(uint32_t id, std::istream* data)
       : id_(id), stream_(data) {}
-  inline DRSCreatorTableEntry(uint32_t id, const fs::path& filename)
-      : id_(id), filename_(filename) {}
+  inline DRSCreatorTableEntry(uint32_t id, fs::path filename)
+      : id_(id), filename_(std::move(filename)) {}
   inline DRSCreatorTableEntry(DRSCreatorTableEntry&& entry)
       : id_(entry.id_), stream_(entry.stream_),
         filename_(std::move(entry.filename_)) {
@@ -78,11 +79,11 @@ public:
 };
 
 inline void DRSCreatorTable::addFile(uint32_t id, std::istream* data) {
-  files_.push_back(DRSCreatorTableEntry(id, data));
+  files_.emplace_back(id, data);
 }
 
 inline void DRSCreatorTable::addFile(uint32_t id, const fs::path& filename) {
-  files_.push_back(DRSCreatorTableEntry(id, filename));
+  files_.emplace_back(id, filename);
 }
 
 inline void DRSCreator::addFile(DRSTableType table, uint32_t id,

--- a/libwololokingdoms/fixes/ai900unitidfix.cpp
+++ b/libwololokingdoms/fixes/ai900unitidfix.cpp
@@ -105,18 +105,16 @@ void swapUnits(genie::DatFile* aocDat, int id1, int id2) {
   // Iterate techs
   for (auto& techIt : aocDat->Effects) {
     // Iterate effects of each tech
-    for (auto techEffectsIt = techIt.EffectCommands.begin(),
-              end = techIt.EffectCommands.end();
-         techEffectsIt != end; ++techEffectsIt) {
-      switch (techEffectsIt->Type) {
+    for (auto& EffectCommand : techIt.EffectCommands) {
+      switch (EffectCommand.Type) {
       case 3: // upgrade unit (this ones uses 2 units hence the special case,
               // notice the absence of break)
-        swapId(&techEffectsIt->UnitClassID, id1, id2);
+        swapId(&EffectCommand.UnitClassID, id1, id2);
       case 0: // attribute modifier
       case 2: // enable/disable unit
       case 4: // attribute modifier (+/-)
       case 5: // attribute modifier (*)
-        swapId(&techEffectsIt->TargetUnit, id1, id2);
+        swapId(&EffectCommand.TargetUnit, id1, id2);
       }
     }
   }
@@ -124,18 +122,16 @@ void swapUnits(genie::DatFile* aocDat, int id1, int id2) {
   // Iterate tech tree ages
   for (auto& ageIt : aocDat->TechTree.TechTreeAges) {
     // Iterate connected units of each age
-    for (auto unitIt = ageIt.Units.begin(), end = ageIt.Units.end();
-         unitIt != end; ++unitIt) {
-      swapId(&(*unitIt), id1, id2);
+    for (int& Unit : ageIt.Units) {
+      swapId(&Unit, id1, id2);
     }
   }
 
   // Iterate tech tree buildings
   for (auto& buildingIt : aocDat->TechTree.BuildingConnections) {
     // Iterate connected units of each age
-    for (auto unitIt = buildingIt.Units.begin(), end = buildingIt.Units.end();
-         unitIt != end; ++unitIt) {
-      swapId(&(*unitIt), id1, id2);
+    for (int& Unit : buildingIt.Units) {
+      swapId(&Unit, id1, id2);
     }
     swapIdInCommon(&buildingIt.Common, id1, id2);
   }
@@ -144,9 +140,8 @@ void swapUnits(genie::DatFile* aocDat, int id1, int id2) {
   for (auto& unitIt : aocDat->TechTree.UnitConnections) {
     swapId(&unitIt.ID, id1, id2);
     // Iterate connected units of each unit
-    for (auto unitUnitIt = unitIt.Units.begin(), end = unitIt.Units.end();
-         unitUnitIt != end; ++unitUnitIt) {
-      swapId(&(*unitUnitIt), id1, id2);
+    for (int& Unit : unitIt.Units) {
+      swapId(&Unit, id1, id2);
     }
     swapIdInCommon(&unitIt.Common, id1, id2);
   }
@@ -154,27 +149,23 @@ void swapUnits(genie::DatFile* aocDat, int id1, int id2) {
   // Iterate tech tree researches
   for (auto& researchIt : aocDat->TechTree.ResearchConnections) {
     // Iterate connected units of each researches
-    for (auto researchUnitIt = researchIt.Units.begin(),
-              end = researchIt.Units.end();
-         researchUnitIt != end; ++researchUnitIt) {
-      swapId(&(*researchUnitIt), id1, id2);
+    for (int& Unit : researchIt.Units) {
+      swapId(&Unit, id1, id2);
     }
     swapIdInCommon(&researchIt.Common, id1, id2);
   }
 
   // Iterate through Civs Units to replace the dead unit graphic if necessary
   for (auto& civIt : aocDat->Civs) {
-    for (auto unitIt = civIt.Units.begin(), end = civIt.Units.end();
-         unitIt != end; ++unitIt) {
-      swapId(&unitIt->DeadUnitID, id1, id2);
+    for (auto& Unit : civIt.Units) {
+      swapId(&Unit.DeadUnitID, id1, id2);
     }
   }
 
   // Iterate through Unit commands (e.g. villagers hunting animals)
   for (auto& unitIt : aocDat->UnitHeaders) {
-    for (auto taskIt = unitIt.TaskList.begin(), end = unitIt.TaskList.end();
-         taskIt != end; ++taskIt) {
-      swapId(&taskIt->UnitID, id1, id2);
+    for (auto& taskIt : unitIt.TaskList) {
+      swapId(&taskIt.UnitID, id1, id2);
     }
   }
 }

--- a/libwololokingdoms/fixes/ai900unitidfix.cpp
+++ b/libwololokingdoms/fixes/ai900unitidfix.cpp
@@ -82,35 +82,31 @@ void swapUnits(genie::DatFile* aocDat, int id1, int id2) {
   genie::UnitHeader tmpHeader = aocDat->UnitHeaders[id1];
   aocDat->UnitHeaders[id1] = aocDat->UnitHeaders[id2];
   aocDat->UnitHeaders[id2] = tmpHeader;
-  for (size_t civIndex = 0; civIndex < aocDat->Civs.size(); ++civIndex) {
+  for (auto& Civ : aocDat->Civs) {
     /* switch all 3 ids around first*/
-    aocDat->Civs[civIndex].Units[id1].ID = id2;
-    aocDat->Civs[civIndex].Units[id1].CopyID = id2;
-    aocDat->Civs[civIndex].Units[id1].BaseID = id2;
-    aocDat->Civs[civIndex].Units[id2].ID = id1;
-    aocDat->Civs[civIndex].Units[id2].CopyID = id1;
-    aocDat->Civs[civIndex].Units[id2].BaseID = id1;
+    Civ.Units[id1].ID = id2;
+    Civ.Units[id1].CopyID = id2;
+    Civ.Units[id1].BaseID = id2;
+    Civ.Units[id2].ID = id1;
+    Civ.Units[id2].CopyID = id1;
+    Civ.Units[id2].BaseID = id1;
     /*switch the units*/
-    genie::Unit tmpUnit = aocDat->Civs[civIndex].Units[id1];
-    aocDat->Civs[civIndex].Units[id1] = aocDat->Civs[civIndex].Units[id2];
-    aocDat->Civs[civIndex].Units[id2] = tmpUnit;
+    genie::Unit tmpUnit = Civ.Units[id1];
+    Civ.Units[id1] = Civ.Units[id2];
+    Civ.Units[id2] = tmpUnit;
     /*switch the unit pointers*/
-    uint32_t tmpPointer = aocDat->Civs[civIndex].UnitPointers[id1];
-    aocDat->Civs[civIndex].UnitPointers[id1] =
-        aocDat->Civs[civIndex].UnitPointers[id2];
-    aocDat->Civs[civIndex].UnitPointers[id2] = tmpPointer;
+    uint32_t tmpPointer = Civ.UnitPointers[id1];
+    Civ.UnitPointers[id1] = Civ.UnitPointers[id2];
+    Civ.UnitPointers[id2] = tmpPointer;
   }
 
   // Then : modify all references to these units
 
   // Iterate techs
-  for (std::vector<genie::Effect>::iterator techIt = aocDat->Effects.begin(),
-                                            end = aocDat->Effects.end();
-       techIt != end; ++techIt) {
+  for (auto& techIt : aocDat->Effects) {
     // Iterate effects of each tech
-    for (std::vector<genie::EffectCommand>::iterator
-             techEffectsIt = techIt->EffectCommands.begin(),
-             end = techIt->EffectCommands.end();
+    for (auto techEffectsIt = techIt.EffectCommands.begin(),
+              end = techIt.EffectCommands.end();
          techEffectsIt != end; ++techEffectsIt) {
       switch (techEffectsIt->Type) {
       case 3: // upgrade unit (this ones uses 2 units hence the special case,
@@ -126,80 +122,57 @@ void swapUnits(genie::DatFile* aocDat, int id1, int id2) {
   }
 
   // Iterate tech tree ages
-  for (std::vector<genie::TechTreeAge>::iterator
-           ageIt = aocDat->TechTree.TechTreeAges.begin(),
-           end = aocDat->TechTree.TechTreeAges.end();
-       ageIt != end; ++ageIt) {
+  for (auto& ageIt : aocDat->TechTree.TechTreeAges) {
     // Iterate connected units of each age
-    for (std::vector<int32_t>::iterator unitIt = ageIt->Units.begin(),
-                                        end = ageIt->Units.end();
+    for (auto unitIt = ageIt.Units.begin(), end = ageIt.Units.end();
          unitIt != end; ++unitIt) {
       swapId(&(*unitIt), id1, id2);
     }
   }
 
   // Iterate tech tree buildings
-  for (std::vector<genie::BuildingConnection>::iterator
-           buildingIt = aocDat->TechTree.BuildingConnections.begin(),
-           end = aocDat->TechTree.BuildingConnections.end();
-       buildingIt != end; buildingIt++) {
+  for (auto& buildingIt : aocDat->TechTree.BuildingConnections) {
     // Iterate connected units of each age
-    for (std::vector<int32_t>::iterator unitIt = buildingIt->Units.begin(),
-                                        end = buildingIt->Units.end();
+    for (auto unitIt = buildingIt.Units.begin(), end = buildingIt.Units.end();
          unitIt != end; ++unitIt) {
       swapId(&(*unitIt), id1, id2);
     }
-    swapIdInCommon(&buildingIt->Common, id1, id2);
+    swapIdInCommon(&buildingIt.Common, id1, id2);
   }
 
   // Iterate tech tree units
-  for (std::vector<genie::UnitConnection>::iterator
-           unitIt = aocDat->TechTree.UnitConnections.begin(),
-           end = aocDat->TechTree.UnitConnections.end();
-       unitIt != end; ++unitIt) {
-    swapId(&unitIt->ID, id1, id2);
+  for (auto& unitIt : aocDat->TechTree.UnitConnections) {
+    swapId(&unitIt.ID, id1, id2);
     // Iterate connected units of each unit
-    for (std::vector<int32_t>::iterator unitUnitIt = unitIt->Units.begin(),
-                                        end = unitIt->Units.end();
+    for (auto unitUnitIt = unitIt.Units.begin(), end = unitIt.Units.end();
          unitUnitIt != end; ++unitUnitIt) {
       swapId(&(*unitUnitIt), id1, id2);
     }
-    swapIdInCommon(&unitIt->Common, id1, id2);
+    swapIdInCommon(&unitIt.Common, id1, id2);
   }
 
   // Iterate tech tree researches
-  for (std::vector<genie::ResearchConnection>::iterator
-           researchIt = aocDat->TechTree.ResearchConnections.begin(),
-           end = aocDat->TechTree.ResearchConnections.end();
-       researchIt != end; researchIt++) {
+  for (auto& researchIt : aocDat->TechTree.ResearchConnections) {
     // Iterate connected units of each researches
-    for (std::vector<int32_t>::iterator
-             researchUnitIt = researchIt->Units.begin(),
-             end = researchIt->Units.end();
+    for (auto researchUnitIt = researchIt.Units.begin(),
+              end = researchIt.Units.end();
          researchUnitIt != end; ++researchUnitIt) {
       swapId(&(*researchUnitIt), id1, id2);
     }
-    swapIdInCommon(&researchIt->Common, id1, id2);
+    swapIdInCommon(&researchIt.Common, id1, id2);
   }
 
   // Iterate through Civs Units to replace the dead unit graphic if necessary
-  for (std::vector<genie::Civ>::iterator civIt = aocDat->Civs.begin(),
-                                         end = aocDat->Civs.end();
-       civIt != end; ++civIt) {
-    for (std::vector<genie::Unit>::iterator unitIt = civIt->Units.begin(),
-                                            end = civIt->Units.end();
+  for (auto& civIt : aocDat->Civs) {
+    for (auto unitIt = civIt.Units.begin(), end = civIt.Units.end();
          unitIt != end; ++unitIt) {
       swapId(&unitIt->DeadUnitID, id1, id2);
     }
   }
 
   // Iterate through Unit commands (e.g. villagers hunting animals)
-  for (std::vector<genie::UnitHeader>::iterator
-           unitIt = aocDat->UnitHeaders.begin(),
-           end = aocDat->UnitHeaders.end();
-       unitIt != end; ++unitIt) {
-    for (std::vector<genie::Task>::iterator taskIt = unitIt->TaskList.begin(),
-                                            end = unitIt->TaskList.end();
+  for (auto& unitIt : aocDat->UnitHeaders) {
+    for (auto taskIt = unitIt.TaskList.begin(), end = unitIt.TaskList.end();
          taskIt != end; ++taskIt) {
       swapId(&taskIt->UnitID, id1, id2);
     }

--- a/libwololokingdoms/fixes/ai900unitidfix.cpp
+++ b/libwololokingdoms/fixes/ai900unitidfix.cpp
@@ -79,25 +79,17 @@ void swapIdInCommon(genie::techtree::Common* common, int id1, int id2) {
 
 void swapUnits(genie::DatFile* aocDat, int id1, int id2) {
   // First : swap the actual units
-  genie::UnitHeader tmpHeader = aocDat->UnitHeaders[id1];
-  aocDat->UnitHeaders[id1] = aocDat->UnitHeaders[id2];
-  aocDat->UnitHeaders[id2] = tmpHeader;
+  std::swap(aocDat->UnitHeaders[id1], aocDat->UnitHeaders[id2]);
   for (auto& Civ : aocDat->Civs) {
-    /* switch all 3 ids around first*/
+    // Fix the IDs
     Civ.Units[id1].ID = id2;
     Civ.Units[id1].CopyID = id2;
     Civ.Units[id1].BaseID = id2;
     Civ.Units[id2].ID = id1;
     Civ.Units[id2].CopyID = id1;
     Civ.Units[id2].BaseID = id1;
-    /*switch the units*/
-    genie::Unit tmpUnit = Civ.Units[id1];
-    Civ.Units[id1] = Civ.Units[id2];
-    Civ.Units[id2] = tmpUnit;
-    /*switch the unit pointers*/
-    uint32_t tmpPointer = Civ.UnitPointers[id1];
-    Civ.UnitPointers[id1] = Civ.UnitPointers[id2];
-    Civ.UnitPointers[id2] = tmpPointer;
+    std::swap(Civ.Units[id1], Civ.Units[id2]);
+    std::swap(Civ.UnitPointers[id1], Civ.UnitPointers[id2]);
   }
 
   // Then : modify all references to these units

--- a/libwololokingdoms/fixes/ai900unitidfix.cpp
+++ b/libwololokingdoms/fixes/ai900unitidfix.cpp
@@ -12,7 +12,7 @@ namespace wololo {
  * work
  */
 
-std::vector<std::pair<int, int>> const unitsIDtoSwap = {
+static const std::vector<std::pair<int, int>> unitsIDtoSwap = {
 
     {1103, 529}, // Fire Galley, Fire Ship
     {1104, 527}, // Demolition Raft, Demolition Ship NOTE: These two are special
@@ -53,7 +53,7 @@ std::vector<std::pair<int, int>> const unitsIDtoSwap = {
     {1122, 891}  // Elite Ballista Ele, SGTWR_D
 };
 
-void swapId(int32_t* val, int32_t id1, int32_t id2) {
+static void swapId(int32_t* val, int32_t id1, int32_t id2) {
   if (*val == id1) {
     *val = id2;
   } else if (*val == id2) {
@@ -61,7 +61,7 @@ void swapId(int32_t* val, int32_t id1, int32_t id2) {
   }
 }
 
-void swapId(int16_t* val, int16_t id1, int16_t id2) {
+static void swapId(int16_t* val, int16_t id1, int16_t id2) {
   if (*val == id1) {
     *val = id2;
   } else if (*val == id2) {
@@ -69,7 +69,7 @@ void swapId(int16_t* val, int16_t id1, int16_t id2) {
   }
 }
 
-void swapIdInCommon(genie::techtree::Common* common, int id1, int id2) {
+static void swapIdInCommon(genie::techtree::Common* common, int id1, int id2) {
   for (int i = 0; i < common->SlotsUsed; i++) {
     if (common->Mode[i] == 2) { // Unit
       swapId(&common->UnitResearch[i], id1, id2);
@@ -77,7 +77,7 @@ void swapIdInCommon(genie::techtree::Common* common, int id1, int id2) {
   }
 }
 
-void swapUnits(genie::DatFile* aocDat, int id1, int id2) {
+static void swapUnits(genie::DatFile* aocDat, int id1, int id2) {
   // First : swap the actual units
   std::swap(aocDat->UnitHeaders[id1], aocDat->UnitHeaders[id2]);
   for (auto& Civ : aocDat->Civs) {

--- a/libwololokingdoms/fixes/berbersutfix.cpp
+++ b/libwololokingdoms/fixes/berbersutfix.cpp
@@ -17,16 +17,14 @@ void berbersUTPatch(genie::DatFile* aocDat) {
   std::vector<genie::EffectCommand>* effectsPtr =
       &aocDat->Effects[berbersUT2TechId].EffectCommands;
   std::vector<genie::EffectCommand> effectsToAdd;
-  for (std::vector<genie::EffectCommand>::iterator it = effectsPtr->begin(),
-                                                   end = effectsPtr->end();
-       it != end; it++) {
+  for (auto& it : *effectsPtr) {
     // set a hero attribute for regen
-    it->Type = 0;         // set attribute
-    it->AttributeID = 40; // hero attribute
-    it->Amount = 4.0f;    // regen
+    it.Type = 0;         // set attribute
+    it.AttributeID = 40; // hero attribute
+    it.Amount = 4.0f;    // regen
 
     // add an attribute to modify the timer
-    effect = *it;
+    effect = it;
     effect.AttributeID = 45;
     effect.Amount = 4.0f;
     effectsToAdd.push_back(effect);

--- a/libwololokingdoms/fixes/cuttingfix.cpp
+++ b/libwololokingdoms/fixes/cuttingfix.cpp
@@ -5,7 +5,7 @@ namespace wololo {
 
 void cuttingPatch(genie::DatFile* aocDat) {
 
-  //TODO: Make sure the regular (cutting) unit remains at the normal ID
+  // TODO: Make sure the regular (cutting) unit remains at the normal ID
 
   // Civ Bonus Fix
   size_t const onagerID = 550;
@@ -36,13 +36,13 @@ void cuttingPatch(genie::DatFile* aocDat) {
   aocDat->UnitHeaders[newOnagerID] = aocDat->UnitHeaders[onagerID];
   aocDat->UnitHeaders[onagerID].TaskList.erase(
       aocDat->UnitHeaders[onagerID].TaskList.begin() + 4);
-  for (size_t i = 0; i < aocDat->Civs.size(); i++) {
-    aocDat->Civs[i].Units[newOnagerID] = aocDat->Civs[i].Units[onagerID];
+  for (auto& Civ : aocDat->Civs) {
+    Civ.Units[newOnagerID] = Civ.Units[onagerID];
     // TODO replace onagerID in here with newOnagerID with the new data upate
-    aocDat->Civs[i].Units[onagerID].Combat.BlastAttackLevel = 2;
-    aocDat->Civs[i].Units[onagerID].LanguageDLLCreation += 205;
-    aocDat->Civs[i].Units[onagerID].LanguageDLLHelp += 205;
-    aocDat->Civs[i].Units[onagerID].LanguageDLLName += 205;
+    Civ.Units[onagerID].Combat.BlastAttackLevel = 2;
+    Civ.Units[onagerID].LanguageDLLCreation += 205;
+    Civ.Units[onagerID].LanguageDLLHelp += 205;
+    Civ.Units[onagerID].LanguageDLLName += 205;
   }
   effect.UnitClassID = newOnagerID;
   aocDat->Effects[onagerCuttingEffectID].EffectCommands.push_back(effect);

--- a/libwololokingdoms/fixes/demoshipfix.cpp
+++ b/libwololokingdoms/fixes/demoshipfix.cpp
@@ -14,10 +14,10 @@ void demoshipPatch(genie::DatFile* aocDat) {
   size_t const heavyDemoShipUnitId = 528;
   // size_t const darkAgeTechId = 104;
 
-  for (size_t civIndex = 0; civIndex < aocDat->Civs.size(); civIndex++) {
-    aocDat->Civs[civIndex].Units[demoRaftUnitId].Creatable.HeroMode = 96;
-    aocDat->Civs[civIndex].Units[demoShipUnitId].Creatable.HeroMode = 96;
-    aocDat->Civs[civIndex].Units[heavyDemoShipUnitId].Creatable.HeroMode = 96;
+  for (auto& Civ : aocDat->Civs) {
+    Civ.Units[demoRaftUnitId].Creatable.HeroMode = 96;
+    Civ.Units[demoShipUnitId].Creatable.HeroMode = 96;
+    Civ.Units[heavyDemoShipUnitId].Creatable.HeroMode = 96;
   }
   /*genie::TechageEffect effect = genie::TechageEffect();
       effect.Type = 0; // set attribute

--- a/libwololokingdoms/fixes/disablenonworkingunits.cpp
+++ b/libwololokingdoms/fixes/disablenonworkingunits.cpp
@@ -8,14 +8,14 @@ void disableNonWorkingUnitsPatch(genie::DatFile* aocDat) {
    * Disabling units that are not supposed to show in the scenario editor
    */
 
-  for (size_t civIndex = 0; civIndex < aocDat->Civs.size(); civIndex++) {
-    aocDat->Civs[civIndex].Units[1119].HideInEditor = 1;
-    aocDat->Civs[civIndex].Units[1145].HideInEditor = 1;
-    aocDat->Civs[civIndex].Units[1147].HideInEditor = 1;
-    aocDat->Civs[civIndex].Units[1221].HideInEditor = 1;
-    aocDat->Civs[civIndex].Units[1401].HideInEditor = 1;
+  for (auto& Civ : aocDat->Civs) {
+    Civ.Units[1119].HideInEditor = 1;
+    Civ.Units[1145].HideInEditor = 1;
+    Civ.Units[1147].HideInEditor = 1;
+    Civ.Units[1221].HideInEditor = 1;
+    Civ.Units[1401].HideInEditor = 1;
     for (size_t unitIndex = 1224; unitIndex <= 1400; unitIndex++) {
-      aocDat->Civs[civIndex].Units[unitIndex].HideInEditor = 1;
+      Civ.Units[unitIndex].HideInEditor = 1;
     }
   }
 }

--- a/libwololokingdoms/fixes/ethiopiansfreepikeupgradefix.cpp
+++ b/libwololokingdoms/fixes/ethiopiansfreepikeupgradefix.cpp
@@ -13,11 +13,9 @@ void ethiopiansPikePatch(genie::DatFile* aocDat) {
 
   std::vector<genie::EffectCommand>* effectsPtr =
       &aocDat->Effects[freePikeHalbTechId].EffectCommands;
-  for (std::vector<genie::EffectCommand>::iterator it = effectsPtr->begin(),
-                                                   end = effectsPtr->end();
-       it != end; it++) {
+  for (auto& it : *effectsPtr) {
     aocDat->Effects[ethiopiansTechTreeTechId].EffectCommands.push_back(
-        *it); // copy the effects into the ethiopians tech tree
+        it); // copy the effects into the ethiopians tech tree
   }
 }
 

--- a/libwololokingdoms/fixes/feitoriafix.cpp
+++ b/libwololokingdoms/fixes/feitoriafix.cpp
@@ -22,79 +22,58 @@ void feitoriaPatch(genie::DatFile* aocDat) {
   int16_t const feitoriaDeadStackId = 1399; // 955
   int16_t const feitoriaStackId = 1400;     // 949
 
-  for (size_t civIndex = 0; civIndex < aocDat->Civs.size(); civIndex++) {
-    aocDat->Civs[civIndex].Units[feitoriaStackId] =
-        aocDat->Civs[civIndex].Units[feitoriaId];
-    aocDat->Civs[civIndex].Units[woodAnnexId] =
-        aocDat->Civs[civIndex].Units[feitoriaId];
-    aocDat->Civs[civIndex].Units[foodAnnexId] =
-        aocDat->Civs[civIndex].Units[feitoriaId];
-    aocDat->Civs[civIndex].Units[goldAnnexId] =
-        aocDat->Civs[civIndex].Units[feitoriaId];
-    aocDat->Civs[civIndex].Units[stoneAnnexId] =
-        aocDat->Civs[civIndex].Units[feitoriaId];
-    aocDat->Civs[civIndex].Units[woodTrickleId] =
-        aocDat->Civs[civIndex].Units[feitoriaId];
-    aocDat->Civs[civIndex].Units[foodTrickleId] =
-        aocDat->Civs[civIndex].Units[feitoriaId];
-    aocDat->Civs[civIndex].Units[goldTrickleId] =
-        aocDat->Civs[civIndex].Units[feitoriaId];
-    aocDat->Civs[civIndex].Units[stoneTrickleId] =
-        aocDat->Civs[civIndex].Units[feitoriaId];
+  for (auto& Civ : aocDat->Civs) {
+    Civ.Units[feitoriaStackId] = Civ.Units[feitoriaId];
+    Civ.Units[woodAnnexId] = Civ.Units[feitoriaId];
+    Civ.Units[foodAnnexId] = Civ.Units[feitoriaId];
+    Civ.Units[goldAnnexId] = Civ.Units[feitoriaId];
+    Civ.Units[stoneAnnexId] = Civ.Units[feitoriaId];
+    Civ.Units[woodTrickleId] = Civ.Units[feitoriaId];
+    Civ.Units[foodTrickleId] = Civ.Units[feitoriaId];
+    Civ.Units[goldTrickleId] = Civ.Units[feitoriaId];
+    Civ.Units[stoneTrickleId] = Civ.Units[feitoriaId];
 
-    aocDat->Civs[civIndex].Units[feitoriaStackId].Name = "Feitoria";
-    aocDat->Civs[civIndex].Units[woodAnnexId].Name = "AA-A Wood Annex";
-    aocDat->Civs[civIndex].Units[foodAnnexId].Name = "AA-A Food Annex";
-    aocDat->Civs[civIndex].Units[goldAnnexId].Name = "AA-A Stone Annex";
-    aocDat->Civs[civIndex].Units[stoneAnnexId].Name = "AA-A gold Annex";
-    aocDat->Civs[civIndex].Units[woodTrickleId].Name = "Wood Trickle";
-    aocDat->Civs[civIndex].Units[foodTrickleId].Name = "Food Trickle";
-    aocDat->Civs[civIndex].Units[goldTrickleId].Name = "Gold Trickle";
-    aocDat->Civs[civIndex].Units[stoneTrickleId].Name = "Stone Trickle";
+    Civ.Units[feitoriaStackId].Name = "Feitoria";
+    Civ.Units[woodAnnexId].Name = "AA-A Wood Annex";
+    Civ.Units[foodAnnexId].Name = "AA-A Food Annex";
+    Civ.Units[goldAnnexId].Name = "AA-A Stone Annex";
+    Civ.Units[stoneAnnexId].Name = "AA-A gold Annex";
+    Civ.Units[woodTrickleId].Name = "Wood Trickle";
+    Civ.Units[foodTrickleId].Name = "Food Trickle";
+    Civ.Units[goldTrickleId].Name = "Gold Trickle";
+    Civ.Units[stoneTrickleId].Name = "Stone Trickle";
 
-    aocDat->Civs[civIndex].Units[feitoriaId].Building.StackUnitID =
-        feitoriaStackId;
-    aocDat->Civs[civIndex].Units[feitoriaId].Building.DisappearsWhenBuilt = 1;
-    aocDat->Civs[civIndex].Units[feitoriaId].HideInEditor = 1;
+    Civ.Units[feitoriaId].Building.StackUnitID = feitoriaStackId;
+    Civ.Units[feitoriaId].Building.DisappearsWhenBuilt = 1;
+    Civ.Units[feitoriaId].HideInEditor = 1;
 
-    aocDat->Civs[civIndex].Units[feitoriaStackId].DyingGraphic = -1;
-    aocDat->Civs[civIndex].Units[feitoriaStackId].UndeadGraphic = -1;
-    aocDat->Civs[civIndex].Units[feitoriaStackId].DeadUnitID =
-        feitoriaDeadStackId;
-    aocDat->Civs[civIndex].Units[feitoriaStackId].OcclusionMode = 6;
-    aocDat->Civs[civIndex].Units[feitoriaStackId].Creatable.TrainLocationID = 0;
-    aocDat->Civs[civIndex].Units[feitoriaStackId].ResourceStorages[2].Type = -1;
-    aocDat->Civs[civIndex].Units[feitoriaStackId].ResourceStorages[2].Amount =
-        0;
-    aocDat->Civs[civIndex].Units[feitoriaStackId].ResourceStorages[2].Paid = 0;
-    aocDat->Civs[civIndex].Units[feitoriaStackId].Building.HeadUnit =
-        feitoriaId;
-    aocDat->Civs[civIndex].Units[feitoriaStackId].Building.Annexes[0].UnitID =
-        woodAnnexId;
-    aocDat->Civs[civIndex].Units[feitoriaStackId].Building.Annexes[1].UnitID =
-        foodAnnexId;
-    aocDat->Civs[civIndex].Units[feitoriaStackId].Building.Annexes[2].UnitID =
-        goldAnnexId;
-    aocDat->Civs[civIndex].Units[feitoriaStackId].Building.Annexes[3].UnitID =
-        stoneAnnexId;
+    Civ.Units[feitoriaStackId].DyingGraphic = -1;
+    Civ.Units[feitoriaStackId].UndeadGraphic = -1;
+    Civ.Units[feitoriaStackId].DeadUnitID = feitoriaDeadStackId;
+    Civ.Units[feitoriaStackId].OcclusionMode = 6;
+    Civ.Units[feitoriaStackId].Creatable.TrainLocationID = 0;
+    Civ.Units[feitoriaStackId].ResourceStorages[2].Type = -1;
+    Civ.Units[feitoriaStackId].ResourceStorages[2].Amount = 0;
+    Civ.Units[feitoriaStackId].ResourceStorages[2].Paid = 0;
+    Civ.Units[feitoriaStackId].Building.HeadUnit = feitoriaId;
+    Civ.Units[feitoriaStackId].Building.Annexes[0].UnitID = woodAnnexId;
+    Civ.Units[feitoriaStackId].Building.Annexes[1].UnitID = foodAnnexId;
+    Civ.Units[feitoriaStackId].Building.Annexes[2].UnitID = goldAnnexId;
+    Civ.Units[feitoriaStackId].Building.Annexes[3].UnitID = stoneAnnexId;
     for (int i = 0; i < 4; i++) {
-      aocDat->Civs[civIndex]
-          .Units[feitoriaStackId]
-          .Building.Annexes[i]
-          .Misplacement = {0.5, 0.5};
+      Civ.Units[feitoriaStackId].Building.Annexes[i].Misplacement = {0.5, 0.5};
     }
 
     // dead unit
-    aocDat->Civs[civIndex].Units[feitoriaDeadStackId].Type = 80;
-    aocDat->Civs[civIndex].Units[feitoriaDeadStackId].Class = 3;
-    aocDat->Civs[civIndex].Units[feitoriaDeadStackId].DyingGraphic = 42;
-    aocDat->Civs[civIndex].Units[feitoriaDeadStackId].UndeadGraphic = -1;
-    aocDat->Civs[civIndex].Units[feitoriaDeadStackId].HitPoints = 0;
-    aocDat->Civs[civIndex].Units[feitoriaDeadStackId].ResourceDecay = 1;
-    aocDat->Civs[civIndex].Units[feitoriaDeadStackId].Enabled = 0;
-    aocDat->Civs[civIndex].Units[feitoriaDeadStackId].HideInEditor = 1;
-    aocDat->Civs[civIndex].Units[feitoriaDeadStackId].DeadUnitID =
-        148; // Rubble 8 x 8
+    Civ.Units[feitoriaDeadStackId].Type = 80;
+    Civ.Units[feitoriaDeadStackId].Class = 3;
+    Civ.Units[feitoriaDeadStackId].DyingGraphic = 42;
+    Civ.Units[feitoriaDeadStackId].UndeadGraphic = -1;
+    Civ.Units[feitoriaDeadStackId].HitPoints = 0;
+    Civ.Units[feitoriaDeadStackId].ResourceDecay = 1;
+    Civ.Units[feitoriaDeadStackId].Enabled = 0;
+    Civ.Units[feitoriaDeadStackId].HideInEditor = 1;
+    Civ.Units[feitoriaDeadStackId].DeadUnitID = 148; // Rubble 8 x 8
 
     // CRASH -> INVALID NAMES for new units ?
 
@@ -106,16 +85,16 @@ void feitoriaPatch(genie::DatFile* aocDat) {
     annex.HideInEditor = 1;
     // wood
     annex.DeadUnitID = woodTrickleId;
-    aocDat->Civs[civIndex].Units[woodAnnexId] = annex;
+    Civ.Units[woodAnnexId] = annex;
     // food
     annex.DeadUnitID = foodTrickleId;
-    aocDat->Civs[civIndex].Units[foodAnnexId] = annex;
+    Civ.Units[foodAnnexId] = annex;
     // gold
     annex.DeadUnitID = goldTrickleId;
-    aocDat->Civs[civIndex].Units[goldAnnexId] = annex;
+    Civ.Units[goldAnnexId] = annex;
     // stone
     annex.DeadUnitID = stoneTrickleId;
-    aocDat->Civs[civIndex].Units[stoneAnnexId] = annex;
+    Civ.Units[stoneAnnexId] = annex;
 
     // trickle
     genie::Unit trickle;
@@ -134,53 +113,53 @@ void feitoriaPatch(genie::DatFile* aocDat) {
     trickle.ResourceStorages[1].Type = 0; // Wood storage
     trickle.ResourceStorages[1].Amount = woodAdded;
     trickle.DeadUnitID = woodTrickleId;
-    aocDat->Civs[civIndex].Units[woodTrickleId] = trickle;
+    Civ.Units[woodTrickleId] = trickle;
     // food
     trickle.ResourceStorages[1].Type = 1; // Food storage
     trickle.ResourceStorages[1].Amount = foodAdded;
     trickle.DeadUnitID = foodTrickleId;
-    aocDat->Civs[civIndex].Units[foodTrickleId] = trickle;
+    Civ.Units[foodTrickleId] = trickle;
     // gold
     trickle.ResourceStorages[1].Type = 3; // Gold storage
     trickle.ResourceStorages[1].Amount = goldAdded;
     trickle.DeadUnitID = goldTrickleId;
-    aocDat->Civs[civIndex].Units[goldTrickleId] = trickle;
+    Civ.Units[goldTrickleId] = trickle;
     // stone
     trickle.ResourceStorages[1].Type = 2; // Stone storage
     trickle.ResourceStorages[1].Amount = stoneAdded;
     trickle.DeadUnitID = stoneTrickleId;
-    aocDat->Civs[civIndex].Units[stoneTrickleId] = trickle;
+    Civ.Units[stoneTrickleId] = trickle;
 
     // Fix IDs
-    aocDat->Civs[civIndex].Units[feitoriaStackId].ID = feitoriaStackId;
-    aocDat->Civs[civIndex].Units[woodAnnexId].ID = woodAnnexId;
-    aocDat->Civs[civIndex].Units[foodAnnexId].ID = foodAnnexId;
-    aocDat->Civs[civIndex].Units[goldAnnexId].ID = goldAnnexId;
-    aocDat->Civs[civIndex].Units[stoneAnnexId].ID = stoneAnnexId;
-    aocDat->Civs[civIndex].Units[woodTrickleId].ID = woodTrickleId;
-    aocDat->Civs[civIndex].Units[foodTrickleId].ID = foodTrickleId;
-    aocDat->Civs[civIndex].Units[goldTrickleId].ID = goldTrickleId;
-    aocDat->Civs[civIndex].Units[stoneTrickleId].ID = stoneTrickleId;
+    Civ.Units[feitoriaStackId].ID = feitoriaStackId;
+    Civ.Units[woodAnnexId].ID = woodAnnexId;
+    Civ.Units[foodAnnexId].ID = foodAnnexId;
+    Civ.Units[goldAnnexId].ID = goldAnnexId;
+    Civ.Units[stoneAnnexId].ID = stoneAnnexId;
+    Civ.Units[woodTrickleId].ID = woodTrickleId;
+    Civ.Units[foodTrickleId].ID = foodTrickleId;
+    Civ.Units[goldTrickleId].ID = goldTrickleId;
+    Civ.Units[stoneTrickleId].ID = stoneTrickleId;
 
-    aocDat->Civs[civIndex].Units[feitoriaStackId].CopyID = feitoriaStackId;
-    aocDat->Civs[civIndex].Units[woodAnnexId].CopyID = woodAnnexId;
-    aocDat->Civs[civIndex].Units[foodAnnexId].CopyID = foodAnnexId;
-    aocDat->Civs[civIndex].Units[goldAnnexId].CopyID = goldAnnexId;
-    aocDat->Civs[civIndex].Units[stoneAnnexId].CopyID = stoneAnnexId;
-    aocDat->Civs[civIndex].Units[woodTrickleId].CopyID = woodTrickleId;
-    aocDat->Civs[civIndex].Units[foodTrickleId].CopyID = foodTrickleId;
-    aocDat->Civs[civIndex].Units[goldTrickleId].CopyID = goldTrickleId;
-    aocDat->Civs[civIndex].Units[stoneTrickleId].CopyID = stoneTrickleId;
+    Civ.Units[feitoriaStackId].CopyID = feitoriaStackId;
+    Civ.Units[woodAnnexId].CopyID = woodAnnexId;
+    Civ.Units[foodAnnexId].CopyID = foodAnnexId;
+    Civ.Units[goldAnnexId].CopyID = goldAnnexId;
+    Civ.Units[stoneAnnexId].CopyID = stoneAnnexId;
+    Civ.Units[woodTrickleId].CopyID = woodTrickleId;
+    Civ.Units[foodTrickleId].CopyID = foodTrickleId;
+    Civ.Units[goldTrickleId].CopyID = goldTrickleId;
+    Civ.Units[stoneTrickleId].CopyID = stoneTrickleId;
 
-    aocDat->Civs[civIndex].Units[feitoriaStackId].BaseID = feitoriaStackId;
-    aocDat->Civs[civIndex].Units[woodAnnexId].BaseID = woodAnnexId;
-    aocDat->Civs[civIndex].Units[foodAnnexId].BaseID = foodAnnexId;
-    aocDat->Civs[civIndex].Units[goldAnnexId].BaseID = goldAnnexId;
-    aocDat->Civs[civIndex].Units[stoneAnnexId].BaseID = stoneAnnexId;
-    aocDat->Civs[civIndex].Units[woodTrickleId].BaseID = woodTrickleId;
-    aocDat->Civs[civIndex].Units[foodTrickleId].BaseID = foodTrickleId;
-    aocDat->Civs[civIndex].Units[goldTrickleId].BaseID = goldTrickleId;
-    aocDat->Civs[civIndex].Units[stoneTrickleId].BaseID = stoneTrickleId;
+    Civ.Units[feitoriaStackId].BaseID = feitoriaStackId;
+    Civ.Units[woodAnnexId].BaseID = woodAnnexId;
+    Civ.Units[foodAnnexId].BaseID = foodAnnexId;
+    Civ.Units[goldAnnexId].BaseID = goldAnnexId;
+    Civ.Units[stoneAnnexId].BaseID = stoneAnnexId;
+    Civ.Units[woodTrickleId].BaseID = woodTrickleId;
+    Civ.Units[foodTrickleId].BaseID = foodTrickleId;
+    Civ.Units[goldTrickleId].BaseID = goldTrickleId;
+    Civ.Units[stoneTrickleId].BaseID = stoneTrickleId;
   }
 }
 

--- a/libwololokingdoms/fixes/hotkeysfix.cpp
+++ b/libwololokingdoms/fixes/hotkeysfix.cpp
@@ -18,7 +18,7 @@ void hotkeysPatch(genie::DatFile* aocDat) {
   int const camelUnitId = 329; // we will use that hotkey for battle elephants
   int const battleEleId = 1132;
 
-  for (size_t civIndex = 0; civIndex < aocDat->Civs.size(); civIndex++) {
+  for (auto& Civ : aocDat->Civs) {
     /*for(int i = palisadeGateUnitIdStart; i<=palisadeGateUnitIdStop; i++) {
                     aocDat->Civs[civIndex].Units[i].HotKey =
     aocDat->Civs[civIndex].Units[wonderUnitId].HotKey;
@@ -36,8 +36,7 @@ void hotkeysPatch(genie::DatFile* aocDat) {
     aocDat->Civs[civIndex].Units[longboatUnitId].HotKey;
     */
 
-    aocDat->Civs[civIndex].Units[battleEleId].HotKey =
-        aocDat->Civs[civIndex].Units[camelUnitId].HotKey;
+    Civ.Units[battleEleId].HotKey = Civ.Units[camelUnitId].HotKey;
   }
 }
 

--- a/libwololokingdoms/fixes/khmerfix.cpp
+++ b/libwololokingdoms/fixes/khmerfix.cpp
@@ -22,11 +22,9 @@ void khmerPatch(genie::DatFile* aocDat) {
   std::vector<genie::EffectCommand>* effectsPtr =
       &aocDat->Effects[khmerBonusTechId].EffectCommands;
   std::vector<genie::EffectCommand> effectsToAdd;
-  for (std::vector<genie::EffectCommand>::iterator it = effectsPtr->begin(),
-                                                   end = effectsPtr->end();
-       it != end; it++) {
+  for (auto& it : *effectsPtr) {
     // add an attribute to disable drop-off
-    effect = *it;
+    effect = it;
     effect.Type = 0;
     effect.AttributeID = 31; // Drop-off of resources
     effect.Amount = 4.0f;
@@ -39,15 +37,14 @@ void khmerPatch(genie::DatFile* aocDat) {
   // use in CtR maps
   aocDat->UnitHeaders[newElephantId] = aocDat->UnitHeaders[ballistaElephantId];
   aocDat->UnitHeaders[newElephantId].TaskList.pop_back();
-  for (size_t i = 0; i < aocDat->Civs.size(); i++) {
-    aocDat->Civs[i].Units[newElephantId] =
-        aocDat->Civs[i].Units[ballistaElephantId];
-    aocDat->Civs[i].Units[newElephantId].Combat.Attacks.erase(
-        aocDat->Civs[i].Units[newElephantId].Combat.Attacks.begin() + 4);
-    aocDat->Civs[i].Units[newElephantId].Combat.BlastAttackLevel = 2;
-    aocDat->Civs[i].Units[newElephantId].LanguageDLLCreation += 508;
-    aocDat->Civs[i].Units[newElephantId].LanguageDLLHelp += 508;
-    aocDat->Civs[i].Units[newElephantId].LanguageDLLName += 508;
+  for (auto& Civ : aocDat->Civs) {
+    Civ.Units[newElephantId] = Civ.Units[ballistaElephantId];
+    Civ.Units[newElephantId].Combat.Attacks.erase(
+        Civ.Units[newElephantId].Combat.Attacks.begin() + 4);
+    Civ.Units[newElephantId].Combat.BlastAttackLevel = 2;
+    Civ.Units[newElephantId].LanguageDLLCreation += 508;
+    Civ.Units[newElephantId].LanguageDLLHelp += 508;
+    Civ.Units[newElephantId].LanguageDLLName += 508;
   }
   aocDat->Effects[doubleCrossbowId].EffectCommands.push_back(
       aocDat->Effects[doubleCrossbowId].EffectCommands[0]);
@@ -80,10 +77,8 @@ void khmerPatch(genie::DatFile* aocDat) {
   aocDat->Techs[khmerBuildingResearchId].RequiredTechs[0] = -1;
   aocDat->Techs[khmerBuildingResearchId].RequiredTechs[1] = -1;
 
-  for (size_t i = 0;
-       i < sizeof(buildingResearchs) / sizeof(buildingResearchs[0]); i++) {
-    aocDat->Techs[buildingResearchs[i]].RequiredTechs[1] =
-        khmerBuildingResearchId;
+  for (unsigned long buildingResearch : buildingResearchs) {
+    aocDat->Techs[buildingResearch].RequiredTechs[1] = khmerBuildingResearchId;
   }
 }
 

--- a/libwololokingdoms/fixes/malayfix.cpp
+++ b/libwololokingdoms/fixes/malayfix.cpp
@@ -19,7 +19,7 @@ void malayPatch(genie::DatFile* aocDat) {
     aocDat->Effects[malayTechTreeId].EffectCommands.push_back(
         aocDat->Effects[malayEffectTechId].EffectCommands[i]);
   }
-  if (aocDat->Effects[fishtrapTechId].EffectCommands.size() == 0 ||
+  if (aocDat->Effects[fishtrapTechId].EffectCommands.empty() ||
       aocDat->Effects[fishtrapTechId].EffectCommands[0].TargetUnit != 88) {
     // Fish trap effect not fixed on HD yet
     genie::EffectCommand effect;

--- a/libwololokingdoms/fixes/maliansfreeminingupgradefix.cpp
+++ b/libwololokingdoms/fixes/maliansfreeminingupgradefix.cpp
@@ -13,11 +13,9 @@ void maliansMiningUpgradesPatch(genie::DatFile* aocDat) {
 
   std::vector<genie::EffectCommand>* effectsPtr =
       &aocDat->Effects[freeMiningUpgradesTechId].EffectCommands;
-  for (std::vector<genie::EffectCommand>::iterator it = effectsPtr->begin(),
-                                                   end = effectsPtr->end();
-       it != end; it++) {
+  for (auto& it : *effectsPtr) {
     aocDat->Effects[maliansTechTreeTechId].EffectCommands.push_back(
-        *it); // copy the effects into the ethiopians tech tree
+        it); // copy the effects into the ethiopians tech tree
   }
 }
 

--- a/libwololokingdoms/fixes/portuguesefix.cpp
+++ b/libwololokingdoms/fixes/portuguesefix.cpp
@@ -39,8 +39,7 @@ void PortuguesePatch(genie::DatFile* aocDat) {
   for (auto& building : aocDat->TechTree.BuildingConnections) {
     // Iterate connected units of each age
     if (building.ID == castleId) {
-      for (std::vector<int32_t>::iterator unitIt = building.Units.begin(),
-                                          end = building.Units.end();
+      for (auto unitIt = building.Units.begin(), end = building.Units.end();
            unitIt != end; ++unitIt) {
         if (*unitIt == petardId) {
           unitIt = building.Units.insert(unitIt, caravelId);
@@ -52,8 +51,7 @@ void PortuguesePatch(genie::DatFile* aocDat) {
     }
     if (building.ID == dockId) {
       bool visited = false;
-      for (std::vector<int32_t>::iterator unitIt = building.Units.begin(),
-                                          end = building.Units.end();
+      for (auto unitIt = building.Units.begin(), end = building.Units.end();
            unitIt != end; ++unitIt) {
         if (*unitIt == caravelId || *unitIt == eliteCaravelId) {
           building.Units.erase(unitIt--);

--- a/libwololokingdoms/fixes/smallfixes.cpp
+++ b/libwololokingdoms/fixes/smallfixes.cpp
@@ -90,8 +90,8 @@ void smallPatches(genie::DatFile* aocDat) {
     aocDat->Civs[civIndex].Units[kingID].Combat.AttackGraphic =
         aocDat->Civs[civIndex].Units[kingID].StandingGraphic.first;
     // fix gate rubbles
-    for (size_t i = 0; i < sizeof(gates) / sizeof(gates[0]); i++) {
-      aocDat->Civs[civIndex].Units[gates[i]].DeadUnitID = 144;
+    for (short gate : gates) {
+      aocDat->Civs[civIndex].Units[gate].DeadUnitID = 144;
     }
   }
   // Fix longboats having an unload ability that could mess with attacks
@@ -110,12 +110,12 @@ void smallPatches(genie::DatFile* aocDat) {
   aocDat->Effects[teutonTeamBonusID].EffectCommands[2].UnitClassID = 1;
 
   // mountains were too small for their graphics
-  for (size_t i = 0; i < sizeof(mountains) / sizeof(mountains[0]); i++) {
-    aocDat->Civs[0].Units[mountains[i]].ClearanceSize = {3, 3};
+  for (short mountain : mountains) {
+    aocDat->Civs[0].Units[mountain].ClearanceSize = {3, 3};
   }
   // fixes galleon sounds
   for (size_t fileID = 5555; fileID < 5563; fileID++) {
-    genie::SoundItem* item = new genie::SoundItem();
+    auto* item = new genie::SoundItem();
     item->ResourceID = fileID;
     item->FileName = "wgal" + std::to_string(fileID - 5554) + ".wav";
     item->Probability = fileID < 5557 ? 5 : 15;
@@ -173,19 +173,17 @@ void smallPatches(genie::DatFile* aocDat) {
   // Have an x-patch upgrade to trade carts that's disabled by default
 
   aocDat->UnitHeaders[xtradeCartId] = aocDat->UnitHeaders[tradeCartId];
-  for (size_t i = 0; i < aocDat->Civs.size(); i++) {
-    aocDat->Civs[i].Units[xtradeCartId] = aocDat->Civs[i].Units[tradeCartId];
-    aocDat->Civs[i].Units[xtradeCartId].HitPoints = 115;
-    aocDat->Civs[i].Units[xtradeCartId].ResourceStorages[0].Amount *= 2;
-    aocDat->Civs[i].Units[xtradeCartId].ResourceStorages[1].Amount *= 2;
-    aocDat->Civs[i].Units[xtradeCartId].ResourceStorages[2].Amount *= 2;
-    aocDat->Civs[i].Units[xtradeCartId].Action.WorkRate *= 1.65;
-    aocDat->Civs[i].Units[xtradeCartId].Creatable.TrainTime *= 1.65;
-    aocDat->Civs[i].Units[xtradeCartId].HitPoints = 115;
-    aocDat->Civs[i].Units[xtradeCartId].Creatable.ResourceCosts[0].Amount *=
-        1.65;
-    aocDat->Civs[i].Units[xtradeCartId].Creatable.ResourceCosts[1].Amount *=
-        1.65;
+  for (auto& Civ : aocDat->Civs) {
+    Civ.Units[xtradeCartId] = Civ.Units[tradeCartId];
+    Civ.Units[xtradeCartId].HitPoints = 115;
+    Civ.Units[xtradeCartId].ResourceStorages[0].Amount *= 2;
+    Civ.Units[xtradeCartId].ResourceStorages[1].Amount *= 2;
+    Civ.Units[xtradeCartId].ResourceStorages[2].Amount *= 2;
+    Civ.Units[xtradeCartId].Action.WorkRate *= 1.65;
+    Civ.Units[xtradeCartId].Creatable.TrainTime *= 1.65;
+    Civ.Units[xtradeCartId].HitPoints = 115;
+    Civ.Units[xtradeCartId].Creatable.ResourceCosts[0].Amount *= 1.65;
+    Civ.Units[xtradeCartId].Creatable.ResourceCosts[1].Amount *= 1.65;
   }
 
   aocDat->Techs[xPatchResearchId] = aocDat->Techs[FireShipDisablerId];

--- a/libwololokingdoms/fixes/tricklebuildingfix.cpp
+++ b/libwololokingdoms/fixes/tricklebuildingfix.cpp
@@ -29,56 +29,44 @@ void trickleBuildingPatch(genie::DatFile* aocDat) {
     aocDat->UnitHeaders[newUnitsStartID + 9].TaskList[0 + i].WorkValue1 = 1;
     int graphic1 = getNewGraphicId(aocDat, i);
     int graphic2 = getNewGraphicId(aocDat, 4 + i);
-    for (size_t j = 0; j < aocDat->Civs.size(); j++) {
-      aocDat->Civs[j].Units[newUnitsStartID + i] =
-          aocDat->Civs[j].Units[tradeWorkshopID];
-      aocDat->Civs[j].Units[newUnitsStartID + i].StandingGraphic.first =
-          graphic1;
-      aocDat->Civs[j].Units[newUnitsStartID + i].Action.DefaultTaskID = 0;
-      aocDat->Civs[j].Units[newUnitsStartID + i].LanguageDLLName =
-          newStringStartID + i;
-      aocDat->Civs[j].Units[newUnitsStartID + i].ID = newUnitsStartID + i;
-      aocDat->Civs[j].Units[newUnitsStartID + i].CopyID = newUnitsStartID + i;
-      aocDat->Civs[j].Units[newUnitsStartID + i].BaseID = newUnitsStartID + i;
-      aocDat->Civs[j].Units[newUnitsStartID + i].Class = 1;
-      aocDat->Civs[j].Units[newUnitsStartID + i].BlastDefenseLevel = 0;
-      aocDat->Civs[j].Units[newUnitsStartID + 4 + i] =
-          aocDat->Civs[j].Units[tradeWorkshopID];
-      aocDat->Civs[j].Units[newUnitsStartID + 4 + i].StandingGraphic.first =
-          graphic2;
-      aocDat->Civs[j].Units[newUnitsStartID + 4 + i].LanguageDLLName =
+    for (auto& Civ : aocDat->Civs) {
+      Civ.Units[newUnitsStartID + i] = Civ.Units[tradeWorkshopID];
+      Civ.Units[newUnitsStartID + i].StandingGraphic.first = graphic1;
+      Civ.Units[newUnitsStartID + i].Action.DefaultTaskID = 0;
+      Civ.Units[newUnitsStartID + i].LanguageDLLName = newStringStartID + i;
+      Civ.Units[newUnitsStartID + i].ID = newUnitsStartID + i;
+      Civ.Units[newUnitsStartID + i].CopyID = newUnitsStartID + i;
+      Civ.Units[newUnitsStartID + i].BaseID = newUnitsStartID + i;
+      Civ.Units[newUnitsStartID + i].Class = 1;
+      Civ.Units[newUnitsStartID + i].BlastDefenseLevel = 0;
+      Civ.Units[newUnitsStartID + 4 + i] = Civ.Units[tradeWorkshopID];
+      Civ.Units[newUnitsStartID + 4 + i].StandingGraphic.first = graphic2;
+      Civ.Units[newUnitsStartID + 4 + i].LanguageDLLName =
           newStringStartID + 4 + i;
-      aocDat->Civs[j].Units[newUnitsStartID + 4 + i].ID =
-          newUnitsStartID + 4 + i;
-      aocDat->Civs[j].Units[newUnitsStartID + 4 + i].CopyID =
-          newUnitsStartID + 4 + i;
-      aocDat->Civs[j].Units[newUnitsStartID + 4 + i].BaseID =
-          newUnitsStartID + 4 + i;
+      Civ.Units[newUnitsStartID + 4 + i].ID = newUnitsStartID + 4 + i;
+      Civ.Units[newUnitsStartID + 4 + i].CopyID = newUnitsStartID + 4 + i;
+      Civ.Units[newUnitsStartID + 4 + i].BaseID = newUnitsStartID + 4 + i;
     }
   }
 
   int graphic1 = getNewGraphicId(aocDat, 8);
   int graphic2 = getNewGraphicId(aocDat, 9);
-  for (size_t j = 0; j < aocDat->Civs.size(); j++) {
-    aocDat->Civs[j].Units[newUnitsStartID + 8] =
-        aocDat->Civs[j].Units[tradeWorkshopID];
-    aocDat->Civs[j].Units[newUnitsStartID + 8].StandingGraphic.first = graphic1;
-    aocDat->Civs[j].Units[newUnitsStartID + 8].Action.DefaultTaskID = 0;
-    aocDat->Civs[j].Units[newUnitsStartID + 8].LanguageDLLName =
-        newStringStartID + 8;
-    aocDat->Civs[j].Units[newUnitsStartID + 8].ID = newUnitsStartID + 8;
-    aocDat->Civs[j].Units[newUnitsStartID + 8].CopyID = newUnitsStartID + 8;
-    aocDat->Civs[j].Units[newUnitsStartID + 8].BaseID = newUnitsStartID + 8;
-    aocDat->Civs[j].Units[newUnitsStartID + 8].Class = 1;
-    aocDat->Civs[j].Units[newUnitsStartID + 8].BlastDefenseLevel = 0;
-    aocDat->Civs[j].Units[newUnitsStartID + 9] =
-        aocDat->Civs[j].Units[tradeWorkshopID];
-    aocDat->Civs[j].Units[newUnitsStartID + 9].StandingGraphic.first = graphic2;
-    aocDat->Civs[j].Units[newUnitsStartID + 9].LanguageDLLName =
-        newStringStartID + 9;
-    aocDat->Civs[j].Units[newUnitsStartID + 9].ID = newUnitsStartID + 9;
-    aocDat->Civs[j].Units[newUnitsStartID + 9].CopyID = newUnitsStartID + 9;
-    aocDat->Civs[j].Units[newUnitsStartID + 9].BaseID = newUnitsStartID + 9;
+  for (auto& Civ : aocDat->Civs) {
+    Civ.Units[newUnitsStartID + 8] = Civ.Units[tradeWorkshopID];
+    Civ.Units[newUnitsStartID + 8].StandingGraphic.first = graphic1;
+    Civ.Units[newUnitsStartID + 8].Action.DefaultTaskID = 0;
+    Civ.Units[newUnitsStartID + 8].LanguageDLLName = newStringStartID + 8;
+    Civ.Units[newUnitsStartID + 8].ID = newUnitsStartID + 8;
+    Civ.Units[newUnitsStartID + 8].CopyID = newUnitsStartID + 8;
+    Civ.Units[newUnitsStartID + 8].BaseID = newUnitsStartID + 8;
+    Civ.Units[newUnitsStartID + 8].Class = 1;
+    Civ.Units[newUnitsStartID + 8].BlastDefenseLevel = 0;
+    Civ.Units[newUnitsStartID + 9] = Civ.Units[tradeWorkshopID];
+    Civ.Units[newUnitsStartID + 9].StandingGraphic.first = graphic2;
+    Civ.Units[newUnitsStartID + 9].LanguageDLLName = newStringStartID + 9;
+    Civ.Units[newUnitsStartID + 9].ID = newUnitsStartID + 9;
+    Civ.Units[newUnitsStartID + 9].CopyID = newUnitsStartID + 9;
+    Civ.Units[newUnitsStartID + 9].BaseID = newUnitsStartID + 9;
   }
 }
 

--- a/libwololokingdoms/libwololokingdoms.cpp
+++ b/libwololokingdoms/libwololokingdoms.cpp
@@ -16,8 +16,8 @@ public:
       : converter(converter), listener(listener) {}
 };
 
-typedef WKSettings* wksettings_t;
-typedef wkconvert_handle* wkconverter_t;
+using wksettings_t = WKSettings*;
+using wkconverter_t = wkconvert_handle*;
 
 extern "C" {
 wksettings_t wksettings_create();
@@ -81,19 +81,19 @@ public:
   void (*onError)(void*, const char*) = nullptr;
   void (*onProgress)(void*, int) = nullptr;
 
-  virtual ~Listener() {}
+  ~Listener() override = default;
 
-  virtual void finished() {
+  void finished() override {
     if (onFinished != nullptr)
       onFinished(context);
   }
 
-  virtual void log(std::string logMessage) {
+  void log(std::string logMessage) override {
     if (onLog != nullptr)
       onLog(context, logMessage.c_str());
   }
 
-  virtual void setInfo(std::string info) {
+  void setInfo(std::string info) override {
     if (onSetInfo != nullptr)
       onSetInfo(context, info.c_str());
   }
@@ -103,7 +103,7 @@ public:
       onError(context, err.what());
   }
 
-  virtual void setProgress(int i) {
+  void setProgress(int i) override {
     if (onProgress != nullptr)
       onProgress(context, i);
   }

--- a/libwololokingdoms/libwololokingdoms.cpp
+++ b/libwololokingdoms/libwololokingdoms.cpp
@@ -21,36 +21,37 @@ using wkconverter_t = wkconvert_handle*;
 
 extern "C" {
 wksettings_t wksettings_create();
-void wksettings_free(wksettings_t);
+void wksettings_free(wksettings_t /*inst*/);
 
 // Configure settings.
-void wksettings_copy_maps(wksettings_t, char enable);
-void wksettings_copy_custom_maps(wksettings_t, char enable);
-void wksettings_restricted_civ_mods(wksettings_t, char enable);
-void wksettings_fix_flags(wksettings_t, char enable);
-void wksettings_replace_tooltips(wksettings_t, char enable);
-void wksettings_use_grid(wksettings_t, char enable);
-void wksettings_use_short_walls(wksettings_t, char enable);
-void wksettings_language(wksettings_t, const char* code);
-void wksettings_patch(wksettings_t, int patch);
-void wksettings_hotkeys(wksettings_t, int choice);
-void wksettings_dlc_level(wksettings_t, int level);
-void wksettings_resource_path(wksettings_t, const path_char_t* path);
-void wksettings_hd_path(wksettings_t, const path_char_t* path);
-void wksettings_output_path(wksettings_t, const path_char_t* path);
-void wksettings_voobly_path(wksettings_t, const path_char_t* path);
-void wksettings_up_path(wksettings_t, const path_char_t* path);
-void wksettings_mod_name(wksettings_t, const path_char_t* name);
+void wksettings_copy_maps(wksettings_t /*inst*/, char enable);
+void wksettings_copy_custom_maps(wksettings_t /*inst*/, char enable);
+void wksettings_restricted_civ_mods(wksettings_t /*inst*/, char enable);
+void wksettings_fix_flags(wksettings_t /*inst*/, char enable);
+void wksettings_replace_tooltips(wksettings_t /*inst*/, char enable);
+void wksettings_use_grid(wksettings_t /*inst*/, char enable);
+void wksettings_use_short_walls(wksettings_t /*inst*/, char enable);
+void wksettings_language(wksettings_t /*inst*/, const char* code);
+void wksettings_patch(wksettings_t /*inst*/, int patch);
+void wksettings_hotkeys(wksettings_t /*inst*/, int choice);
+void wksettings_dlc_level(wksettings_t /*inst*/, int level);
+void wksettings_resource_path(wksettings_t /*inst*/, const path_char_t* path);
+void wksettings_hd_path(wksettings_t /*inst*/, const path_char_t* path);
+void wksettings_output_path(wksettings_t /*inst*/, const path_char_t* path);
+void wksettings_voobly_path(wksettings_t /*inst*/, const path_char_t* path);
+void wksettings_up_path(wksettings_t /*inst*/, const path_char_t* path);
+void wksettings_mod_name(wksettings_t /*inst*/, const path_char_t* name);
 
 // Add mods.
-void wksettings_data_mod(wksettings_t, const char* name, const char* exe,
-                         const char* version, int flags, const char* exe2);
-void wksettings_drs_resources(wksettings_t, const path_char_t* dir,
+void wksettings_data_mod(wksettings_t /*inst*/, const char* name,
+                         const char* exe, const char* version, int flags,
+                         const char* exe2);
+void wksettings_drs_resources(wksettings_t /*inst*/, const path_char_t* dir,
                               WKSettings::IndexType type);
 
 // Converter setup.
 wkconverter_t wkconverter_create(wksettings_t settings, void* context);
-void wkconverter_free(wkconverter_t);
+void wkconverter_free(wkconverter_t /*inst*/);
 
 // Callbacks.
 void wkconverter_on_finished(wkconverter_t inst, void (*onFinished)(void*));
@@ -63,7 +64,7 @@ void wkconverter_on_progress(wkconverter_t inst,
                              void (*onProgress)(void*, int));
 
 // Run the converter.
-int wkconverter_run(wkconverter_t);
+int wkconverter_run(wkconverter_t /*inst*/);
 
 // Convenience wrapper.
 int wkconvert(wksettings_t settings, void* context);
@@ -114,10 +115,7 @@ public:
 
 extern "C" wksettings_t wksettings_create() { return new WKSettings(); }
 
-extern "C" void wksettings_free(wksettings_t inst) {
-  if (inst != nullptr)
-    delete inst;
-}
+extern "C" void wksettings_free(wksettings_t inst) { delete inst; }
 
 extern "C" void wksettings_copy_maps(wksettings_t inst, char enable) {
   inst->copyMaps = enable != 0;
@@ -242,10 +240,7 @@ extern "C" void wkconverter_on_progress(wkconverter_t inst,
   inst->listener->onProgress = onProgress;
 }
 
-extern "C" void wkconverter_free(wkconverter_t inst) {
-  if (inst != nullptr)
-    delete inst;
-}
+extern "C" void wkconverter_free(wkconverter_t inst) { delete inst; }
 
 extern "C" int wkconverter_run(wkconverter_t inst) {
   try {

--- a/libwololokingdoms/libwololokingdoms.h
+++ b/libwololokingdoms/libwololokingdoms.h
@@ -5,7 +5,7 @@ extern "C" {
 #ifdef _WIN32
 typedef unsigned short path_char_t;
 #else
-typedef char path_char_t;
+using path_char_t = char;
 #endif
 
 enum WKIndexType {
@@ -15,7 +15,7 @@ enum WKIndexType {
 };
 
 // Create settings.
-typedef void* wksettings_t;
+using wksettings_t = void*;
 wksettings_t wksettings_create();
 void wksettings_free(wksettings_t);
 
@@ -46,7 +46,7 @@ void wksettings_drs_resources(wksettings_t, const path_char_t* dir,
                               enum WKIndexType type);
 
 // Converter setup.
-typedef void* wkconverter_t;
+using wkconverter_t = void*;
 wkconverter_t wkconverter_create(wksettings_t settings, void* context);
 void wkconverter_free(wkconverter_t);
 

--- a/libwololokingdoms/md5.cpp
+++ b/libwololokingdoms/md5.cpp
@@ -154,7 +154,11 @@ void MD5::encode(uint1 output[], const uint4 input[], size_type len) {
 
 // apply MD5 algo on a block
 void MD5::transform(const uint1 block[blocksize]) {
-  uint4 a = state[0], b = state[1], c = state[2], d = state[3], x[16];
+  uint4 a = state[0];
+  uint4 b = state[1];
+  uint4 c = state[2];
+  uint4 d = state[3];
+  uint4 x[16];
   decode(x, block, blocksize);
 
   /* Round 1 */

--- a/libwololokingdoms/md5.h
+++ b/libwololokingdoms/md5.h
@@ -53,8 +53,8 @@ public:
 
   MD5();
   MD5(const std::string& text);
-  void update(const unsigned char* buf, size_type length);
-  void update(const char* buf, size_type length);
+  void update(const unsigned char* input, size_type length);
+  void update(const char* input, size_type length);
   MD5& finalize();
   [[nodiscard]] std::string hexdigest() const;
   [[nodiscard]] std::string b64digest() const;
@@ -92,6 +92,6 @@ private:
                         uint4 ac);
 };
 
-std::string md5(const std::string str);
+std::string md5(std::string str);
 
 #endif

--- a/libwololokingdoms/md5.h
+++ b/libwololokingdoms/md5.h
@@ -49,21 +49,21 @@ documentation and/or software.
 // assumes that char is 8 bit and int is 32 bit
 class MD5 {
 public:
-  typedef unsigned int size_type; // must be 32bit
+  using size_type = unsigned int; // must be 32bit
 
   MD5();
   MD5(const std::string& text);
   void update(const unsigned char* buf, size_type length);
   void update(const char* buf, size_type length);
   MD5& finalize();
-  std::string hexdigest() const;
-  std::string b64digest() const;
+  [[nodiscard]] std::string hexdigest() const;
+  [[nodiscard]] std::string b64digest() const;
   friend std::ostream& operator<<(std::ostream&, MD5 md5);
 
 private:
   void init();
-  typedef unsigned char uint1; //  8bit
-  typedef unsigned int uint4;  // 32bit
+  using uint1 = unsigned char; //  8bit
+  using uint4 = unsigned int;  // 32bit
   enum { blocksize = 64 };     // VC6 won't eat a const static int here
 
   void transform(const uint1 block[blocksize]);

--- a/libwololokingdoms/string_helpers.cpp
+++ b/libwololokingdoms/string_helpers.cpp
@@ -53,14 +53,15 @@ std::string iconvert(const std::string& input, const std::string& from,
 #endif
   auto in_size = input.length();
   size_t out_size = in_size * 2;
-  char* result = new char[out_size];
-  char* out = result; // separate value because iconv advances the pointer
-
   iconv_t convert = iconv_open(to.c_str(), from.c_str());
   if (convert == (iconv_t)-1) {
     return "";
   }
+
+  char* result = new char[out_size];
+  char* out = result; // separate value because iconv advances the pointer
   if (iconv(convert, &in_str, &in_size, &out, &out_size) == (size_t)-1) {
+    delete[] result;
     return "";
   }
   *out = '\0';

--- a/libwololokingdoms/wk_xml.h
+++ b/libwololokingdoms/wk_xml.h
@@ -4,4 +4,4 @@
 /**
  * Handles writing the mod XML file for a given patch level.
  */
-void write_wk_xml(std::ostream& output, int patch_level);
+void write_wk_xml(std::ostream& output, int dlc_level);

--- a/libwololokingdoms/wkconverter.cpp
+++ b/libwololokingdoms/wkconverter.cpp
@@ -1123,20 +1123,23 @@ void WKConverter::upgradeTrees(int usedTerrain, int oldTerrain,
 }
 
 bool contains_rms_word(std::string_view haystack, std::string_view needle) {
-  auto index = haystack.find(needle);
-  if (index == std::string_view::npos) {
-    return false;
-  } else {
+  size_t index = 0;
+  while (true) {
+    index = haystack.find(needle, index);
+    if (index == std::string_view::npos) {
+      return false;
+    }
+    auto endOfName = index + needle.size();
     // We can only check for whitespace, because the RMS parser in the game is
     // extremely whitespace sensitive. For example, it parser `WATER)` as a
     // single word, not `WATER` followed by `)`.
-    auto endOfName = index + needle.size();
-    if ((index > 0 && !std::isspace(haystack[index - 1])) ||
-        (endOfName < haystack.size() - 1 && !std::isspace(haystack[endOfName]))) {
-      return false;
+    if ((index == 0 || std::isspace(haystack[index - 1])) &&
+        (endOfName == haystack.size() - 1 || std::isspace(haystack[endOfName]))) {
+      return true;
     }
+
+    index += 1;
   }
-  return true;
 }
 
 static constexpr auto rxForest =

--- a/libwololokingdoms/wkconverter.cpp
+++ b/libwololokingdoms/wkconverter.cpp
@@ -2454,7 +2454,7 @@ int WKConverter::run() {
       listener->setInfo("working$\n$workingHD");
       genie::DatFile hdDat;
       hdDat.setGameVersion(genie::GameVersion::GV_Cysion);
-      hdDat.load(hdDatPath.string().c_str());
+      hdDat.load(hdDatPath.string());
       listener->increaseProgress(3); // 32
 
       listener->setInfo("working$\n$workingDat");

--- a/libwololokingdoms/wkconverter.cpp
+++ b/libwololokingdoms/wkconverter.cpp
@@ -42,7 +42,8 @@ const fs::path resolve_path(const fs::path& input) {
 #endif
 }
 
-void WKConverter::loadGameStrings(std::map<int, std::string>& langReplacement, fs::path file) {
+void WKConverter::loadGameStrings(std::map<int, std::string>& langReplacement,
+                                  fs::path file) {
   std::string line;
   std::ifstream translationFile(file);
   while (std::getline(translationFile, line)) {
@@ -1033,9 +1034,9 @@ bool WKConverter::usesMultipleWaterTerrains(const std::string& map,
 
 void WKConverter::upgradeTrees(int usedTerrain, int oldTerrain,
                                std::string& map) {
-  static const auto rxPlayerSetup = std::regex("<PLAYER_SETUP>\\s*(\\r*)\\n");
+  static const auto rxPlayerSetup = std::regex(R"(<PLAYER_SETUP>\s*(\r*)\n)");
   static const auto rxIncludeDrs =
-      std::regex("#include_drs\\s+random_map\\.def\\s*(\\r*)\\n");
+      std::regex(R"(#include_drs\s+random_map\.def\s*(\r*)\n)");
 
   std::string newTree;
   std::string oldTree;
@@ -1140,14 +1141,14 @@ void WKConverter::transferHdDatElements(genie::DatFile* hdDat,
   terrainSwap(hdDat, aocDat, 41, 50, 15013); // acacia forest
   terrainSwap(hdDat, aocDat, 16, 49, 15025); // baobab forest
 
-  const std::array<std::tuple<int, std::string>, 7> newTerrainSlps = {{
-      {15012, "DLC_MANGROVEFOREST.slp"},
-      {15013, "ACACIA_FOREST.slp"},
-      {15025, "BAOBAB.slp"},
-      {15003, "15003.slp"},
-      {15032, "CRACKEDIT.slp"},
-      {15034, "ICE_SOLID.slp"},
-      {15020, "ICE_BEACH.slp"}}};
+  const std::array<std::tuple<int, std::string>, 7> newTerrainSlps = {
+      {{15012, "DLC_MANGROVEFOREST.slp"},
+       {15013, "ACACIA_FOREST.slp"},
+       {15025, "BAOBAB.slp"},
+       {15003, "15003.slp"},
+       {15032, "CRACKEDIT.slp"},
+       {15034, "ICE_SOLID.slp"},
+       {15020, "ICE_BEACH.slp"}}};
 
   for (auto& [id, name] : newTerrainSlps) {
     if (slpFiles[id].empty())
@@ -1657,8 +1658,7 @@ short WKConverter::duplicateGraphic(genie::DatFile* aocDat,
      * comparison, this is usually with damage graphics and different amount of
      * Flames.
      */
-    std::vector<genie::GraphicDelta>::iterator compIt =
-        aocDat->Graphics[compareID].Deltas.begin();
+    auto compIt = aocDat->Graphics[compareID].Deltas.begin();
     for (auto& it : newGraphic.Deltas) {
       if (it.GraphicID != -1 &&
           std::find(duplicatedGraphics.begin(), duplicatedGraphics.end(),
@@ -1943,14 +1943,17 @@ static void addOldMonkGraphics(std::map<int, fs::path>& slpFiles,
  * @param oldPath The directory/file the symlink references.
  * @param newPath The directory/file the symlink should be created in.
  * @param type Soft for files, Dir for directories
- * @param copyOldContents possible contents of the newPath folder are copied to oldPath before the symlink is created
+ * @param copyOldContents possible contents of the newPath folder are copied to
+ * oldPath before the symlink is created
  */
 void WKConverter::refreshSymlink(const fs::path& oldPath,
-                                 const fs::path& newPath, const LinkType type, bool copyOldContents) {
+                                 const fs::path& newPath, const LinkType type,
+                                 bool copyOldContents) {
   if (cfs::is_symlink(newPath))
     return;
   if (copyOldContents && cfs::exists(newPath))
-    cfs::copy(newPath, oldPath, cfs::copy_options::skip_existing | cfs::copy_options::recursive);
+    cfs::copy(newPath, oldPath,
+              cfs::copy_options::skip_existing | cfs::copy_options::recursive);
   cfs::remove_all(newPath);
   mklink(type, resolve_path(newPath), resolve_path(oldPath));
 }
@@ -1998,7 +2001,7 @@ void WKConverter::symlinkSetup(const fs::path& oldDir, const fs::path& newDir,
     if (!vooblyDst) {
       refreshSymlink(oldDir / "SaveGame", newDir / "SaveGame", LinkType::Dir,
                      true);
-	}
+    }
     if (!vooblySrc) {
       refreshSymlink(oldDir / "Data" / "language_x1_p1.dll",
                      newDir / "Data" / "language_x1_p1.dll", LinkType::Soft);

--- a/libwololokingdoms/wkconverter.cpp
+++ b/libwololokingdoms/wkconverter.cpp
@@ -1020,7 +1020,7 @@ void WKConverter::copyHDMaps(const fs::path& inputDir,
         map = std::regex_replace(map, std::regex(terrainName),
                                  "MY" + replacement.replaced_name);
         std::regex terrainConstDef =
-            std::regex("#const\\sMY+" + terrainName + "\\s+" +
+            std::regex("#const\\s+MY" + terrainName + "\\s+" +
                        std::to_string(replacement.old_terrain_id));
         std::string temp =
             std::regex_replace(map, terrainConstDef,

--- a/libwololokingdoms/wkconverter.cpp
+++ b/libwololokingdoms/wkconverter.cpp
@@ -1075,12 +1075,13 @@ void WKConverter::copyHDMaps(const fs::path& inputDir,
   listener->increaseProgress(1); // 16+20 22?
 }
 
-static constexpr auto rxAnyWatterConst =
-    ctll::fixed_string(R"(\W(MED_|DEEP_)?WATER|DLC_WATER[45]\W)");
+// Match WATER, MED_WATER, DEEP_WATER, DLC_WATER4, DLC_WATER5
+static constexpr auto rxAnyWaterConst =
+    ctll::fixed_string(R"(\W(?:(MED_|DEEP_)?WATER|DLC_WATER[45])\W)");
 bool WKConverter::usesMultipleWaterTerrains(const std::string& map,
                                             std::map<int, bool>& terrainsUsed) {
   if (!terrainsUsed[23]) {
-    terrainsUsed[23] = ctre::search<rxAnyWatterConst>(map);
+    terrainsUsed[23] = ctre::search<rxAnyWaterConst>(map);
   }
   return terrainsUsed[23];
 }

--- a/libwololokingdoms/wkconverter.h
+++ b/libwololokingdoms/wkconverter.h
@@ -144,16 +144,16 @@ private:
 
   void copyHDMaps(const fs::path& inputDir, const fs::path& outputDir,
                   bool replace = false);
-  bool usesMultipleWaterTerrains(const std::string& map,
-                                 std::map<int, bool>& terrainsUsed);
-  bool isTerrainUsed(int terrain, std::map<int, bool>& terrainsUsed,
-                     const std::string& map,
-                     const std::map<int, std::regex>& patterns);
-  void upgradeTrees(int usedTerrain, int oldTerrain, std::string& map);
-  void createZRmap(std::map<std::string, fs::path>& terrainOverrides,
-                   fs::path outputDir, std::string mapName);
-  void terrainSwap(genie::DatFile* hdDat, genie::DatFile* aocDat, int tNew,
-                   int tOld, int slpID);
+  static bool usesMultipleWaterTerrains(const std::string& map,
+                                        std::map<int, bool>& terrainsUsed);
+  static bool isTerrainUsed(int terrain, std::map<int, bool>& terrainsUsed,
+                            const std::string& map,
+                            const std::map<int, std::regex>& patterns);
+  static void upgradeTrees(int usedTerrain, int oldTerrain, std::string& map);
+  static void createZRmap(std::map<std::string, fs::path>& terrainOverrides,
+                          fs::path outputDir, std::string mapName);
+  static void terrainSwap(genie::DatFile* hdDat, genie::DatFile* aocDat,
+                          int tNew, int tOld, int slpID);
   void indexDrsFiles(fs::path const& src, bool expansionFiles = true,
                      bool terrainFiles = false);
   inline void indexDrsFiles(fs::path const& src, WKSettings::IndexType flags) {
@@ -161,23 +161,27 @@ private:
         src, static_cast<int>(flags & WKSettings::IndexType::Expansion) != 0,
         static_cast<int>(flags & WKSettings::IndexType::Terrain) != 0);
   }
-  void copyHistoryFiles(fs::path inputDir, fs::path outputDir);
-  std::pair<int, std::string> parseHDTextLine(std::string line);
+  static void copyHistoryFiles(fs::path inputDir, fs::path outputDir);
+  static std::pair<int, std::string> parseHDTextLine(std::string line);
   void convertLanguageFile(std::ifstream& in, std::ofstream& iniOut,
                            std::map<int, std::string>& langReplacement);
   void createLanguageFile(fs::path languageIniPath, fs::path patchFolder);
-  void loadGameStrings(std::map<int, std::string>& langReplacement,
-                       fs::path file);
-  void loadModdedStrings(fs::path moddedStringsFile,
-                         std::map<int, std::string>& langReplacement);
-  void makeRandomMapScriptsDrs(std::ofstream& out, const fs::path& drsDir);
+  static void loadGameStrings(std::map<int, std::string>& langReplacement,
+                              fs::path file);
+  static void loadModdedStrings(fs::path moddedStringsFile,
+                                std::map<int, std::string>& langReplacement);
+  static void makeRandomMapScriptsDrs(std::ofstream& out,
+                                      const fs::path& drsDir);
   void makeDrs(std::ofstream& out);
   void editDrs(std::ifstream* in, std::ofstream* out);
-  void copyCivIntroSounds(const fs::path& inputDir, const fs::path& outputDir);
+  static void copyCivIntroSounds(const fs::path& inputDir,
+                                 const fs::path& outputDir);
   void copyWallFiles(const fs::path& inputDir);
-  void createMusicPlaylist(const fs::path& inputDir, const fs::path& outputDir);
+  static void createMusicPlaylist(const fs::path& inputDir,
+                                  const fs::path& outputDir);
   void transferHdDatElements(genie::DatFile* hdDat, genie::DatFile* aocDat);
-  void adjustArchitectureFlags(genie::DatFile* aocDat, fs::path flagFilename);
+  static void adjustArchitectureFlags(genie::DatFile* aocDat,
+                                      fs::path flagFilename);
   void patchArchitectures(genie::DatFile* aocDat);
   bool checkGraphics(genie::DatFile* aocDat, short graphicID,
                      std::vector<int> checkedGraphics);
@@ -188,14 +192,14 @@ private:
                          std::map<short, short>& replacedGraphics,
                          std::vector<short> duplicatedGraphics, short graphicID,
                          short compareID, short offset, bool civGroups = false);
-  bool identifyHotkeyFile(const fs::path& directory, fs::path& maxHki,
-                          fs::path& lastEditedHki);
-  void copyHotkeyFile(const fs::path& maxHki, const fs::path& lastEditedHki,
-                      fs::path dst);
+  static bool identifyHotkeyFile(const fs::path& directory, fs::path& maxHki,
+                                 fs::path& lastEditedHki);
+  static void copyHotkeyFile(const fs::path& maxHki,
+                             const fs::path& lastEditedHki, fs::path dst);
   void removeWkHotkeys();
   void hotkeySetup();
-  void refreshSymlink(const fs::path& oldDir, const fs::path& newDir,
-                      const LinkType type, bool copyOldContents = false);
+  static void refreshSymlink(const fs::path& oldPath, const fs::path& newPath,
+                             LinkType type, bool copyOldContents = false);
   void symlinkSetup(const fs::path& oldDir, const fs::path& newDir,
                     bool dataMod = false);
   void setupFolders(fs::path xmlOutPathUP);

--- a/libwololokingdoms/wkconverter.h
+++ b/libwololokingdoms/wkconverter.h
@@ -5,7 +5,6 @@
 #include "wksettings.h"
 #include <fs.h>
 #include <map>
-#include <optional>
 #include <regex>
 #include <set>
 #include <string>
@@ -163,8 +162,6 @@ private:
         static_cast<int>(flags & WKSettings::IndexType::Terrain) != 0);
   }
   static void copyHistoryFiles(fs::path inputDir, fs::path outputDir);
-  static std::pair<int, std::string> parseHDTextLine(std::string line);
-  static std::optional<std::pair<int, std::string>> parseHDTextLine(std::string line) const noexcept;
   void convertLanguageFile(std::ifstream& in, std::ofstream& iniOut,
                            std::map<int, std::string>& langReplacement);
   void createLanguageFile(fs::path languageIniPath, fs::path patchFolder);

--- a/libwololokingdoms/wkconverter.h
+++ b/libwololokingdoms/wkconverter.h
@@ -124,24 +124,6 @@ private:
   std::string baseModName = "WololoKingdoms";
   fs::path resourceDir = "resources";
 
-  enum TerrainType {
-    None,
-    WaterTerrain,
-    FixedTerrain,
-    LandTerrain,
-    ForestTerrain,
-    UnbuildableTerrain
-  };
-
-  struct MapConvertData {
-    std::string slp_name;
-    std::vector<std::string> const_names;
-    std::string replaced_name;
-    int old_terrain_id;
-    int new_terrain_id;
-    TerrainType terrain_type;
-  };
-
   void copyHDMaps(const fs::path& inputDir, const fs::path& outputDir,
                   bool replace = false);
   static bool usesMultipleWaterTerrains(const std::string& map,

--- a/libwololokingdoms/wkconverter.h
+++ b/libwololokingdoms/wkconverter.h
@@ -130,7 +130,7 @@ private:
                                         std::map<int, bool>& terrainsUsed);
   static bool isTerrainUsed(int terrain, std::map<int, bool>& terrainsUsed,
                             const std::string& map,
-                            const std::map<int, std::regex>& patterns);
+                            const std::map<int, std::string_view>& constNames);
   static void upgradeTrees(int usedTerrain, int oldTerrain, std::string& map);
   static void createZRmap(std::map<std::string, fs::path>& terrainOverrides,
                           fs::path outputDir, std::string mapName);

--- a/libwololokingdoms/wkconverter.h
+++ b/libwololokingdoms/wkconverter.h
@@ -144,8 +144,8 @@ private:
         static_cast<int>(flags & WKSettings::IndexType::Terrain) != 0);
   }
   static void copyHistoryFiles(fs::path inputDir, fs::path outputDir);
-  void convertLanguageFile(std::ifstream& in, std::ofstream& iniOut,
-                           std::map<int, std::string>& langReplacement);
+  static void convertLanguageFile(std::ifstream& in, std::ofstream& iniOut,
+                                  std::map<int, std::string>& langReplacement);
   void createLanguageFile(fs::path languageIniPath, fs::path patchFolder);
   static void loadGameStrings(std::map<int, std::string>& langReplacement,
                               fs::path file);
@@ -181,7 +181,7 @@ private:
   void hotkeySetup();
   static void refreshSymlink(const fs::path& oldPath, const fs::path& newPath,
                              LinkType type, bool copyOldContents = false);
-  void symlinkSetup(const fs::path& oldDir, const fs::path& newDir,
-                    bool dataMod = false);
+  static void symlinkSetup(const fs::path& oldDir, const fs::path& newDir,
+                           bool dataMod = false);
   void setupFolders(fs::path xmlOutPathUP);
 };

--- a/libwololokingdoms/wkconverter.h
+++ b/libwololokingdoms/wkconverter.h
@@ -5,6 +5,7 @@
 #include "wksettings.h"
 #include <fs.h>
 #include <map>
+#include <optional>
 #include <regex>
 #include <set>
 #include <string>
@@ -163,6 +164,7 @@ private:
   }
   static void copyHistoryFiles(fs::path inputDir, fs::path outputDir);
   static std::pair<int, std::string> parseHDTextLine(std::string line);
+  static std::optional<std::pair<int, std::string>> parseHDTextLine(std::string line) const noexcept;
   void convertLanguageFile(std::ifstream& in, std::ofstream& iniOut,
                            std::map<int, std::string>& langReplacement);
   void createLanguageFile(fs::path languageIniPath, fs::path patchFolder);

--- a/libwololokingdoms/wkconverter.h
+++ b/libwololokingdoms/wkconverter.h
@@ -18,7 +18,7 @@ class WKConvertListener {
   int m_cachedProgress = 0;
 
 public:
-  virtual ~WKConvertListener() {}
+  virtual ~WKConvertListener() = default;
 
   /**
    * Called when conversion has finished.
@@ -39,12 +39,14 @@ public:
   /**
    * Report an error.
    */
-  virtual void error([[maybe_unused]] std::exception const& err, bool showDialog = false) {}
+  virtual void error([[maybe_unused]] std::exception const& err,
+                     bool showDialog = false) {}
 
   /**
    * Report an error (message only).
    */
-  virtual void error([[maybe_unused]] std::string message, bool showDialog = false) {
+  virtual void error([[maybe_unused]] std::string message,
+                     bool showDialog = false) {
     error(std::runtime_error(message), showDialog);
   }
 
@@ -164,7 +166,8 @@ private:
   void convertLanguageFile(std::ifstream& in, std::ofstream& iniOut,
                            std::map<int, std::string>& langReplacement);
   void createLanguageFile(fs::path languageIniPath, fs::path patchFolder);
-  void loadGameStrings(std::map<int, std::string>& langReplacement, fs::path file);
+  void loadGameStrings(std::map<int, std::string>& langReplacement,
+                       fs::path file);
   void loadModdedStrings(fs::path moddedStringsFile,
                          std::map<int, std::string>& langReplacement);
   void makeRandomMapScriptsDrs(std::ofstream& out, const fs::path& drsDir);

--- a/libwololokingdoms/wksettings.h
+++ b/libwololokingdoms/wksettings.h
@@ -50,7 +50,7 @@ public:
 
   inline void addDrsResources(const fs::path& directory,
                               IndexType type = IndexType::Expansion) {
-    drsModDirectories.push_back(std::make_pair(directory, type));
+    drsModDirectories.emplace_back(directory, type);
   }
 };
 

--- a/libwololokingdoms/zr_map_creator.cpp
+++ b/libwololokingdoms/zr_map_creator.cpp
@@ -6,7 +6,7 @@ size_t ZRMapCreator::zipWriteCallback(void* context,
                                       [[maybe_unused]] mz_uint64 offset,
                                       const void* buffer, size_t size) {
   const char* char_buffer = reinterpret_cast<const char*>(buffer);
-  ZRMapCreator* map_creator = reinterpret_cast<ZRMapCreator*>(context);
+  auto* map_creator = reinterpret_cast<ZRMapCreator*>(context);
 
   map_creator->output.write(char_buffer, size);
   return size;

--- a/main.cpp
+++ b/main.cpp
@@ -3,7 +3,7 @@
 #include <QCommandLineParser>
 #include <QMessageBox>
 #ifndef _WIN32
-#include <stdlib.h>
+#include <cstdlib>
 #endif
 
 bool can_run_windows_programs() {

--- a/main.cpp
+++ b/main.cpp
@@ -19,8 +19,8 @@ bool can_run_windows_programs() {
 int main(int argc, char* argv[]) {
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QApplication application(argc, argv);
-  application.setApplicationName("WololoKingdoms");
-  application.setApplicationVersion("5.8.1.6");
+  QApplication::setApplicationName("WololoKingdoms");
+  QApplication::setApplicationVersion("5.8.1.6");
 
   QCommandLineParser cli;
   cli.setApplicationDescription(
@@ -47,5 +47,5 @@ int main(int argc, char* argv[]) {
 
   window.show();
 
-  return application.exec();
+  return QApplication::exec();
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -443,7 +443,7 @@ bool MainWindow::checkSteamApi() {
   QDialog* dialog;
   QProcess process;
   SteamAPI_Init();
-  if (!SteamApps()) {
+  if (SteamApps() == nullptr) {
     steamPath = getSteamPath();
     // open steam
     process.start(QString::fromStdString(
@@ -452,23 +452,21 @@ bool MainWindow::checkSteamApi() {
     SteamAPI_Init();
   }
   int tries = 0;
-  while (!SteamApps() && tries < 40) {
+  while ((SteamApps() == nullptr) && tries < 40) {
     std::this_thread::sleep_for(std::chrono::seconds(1));
     SteamAPI_Init();
     tries++;
   }
-  if (!SteamApps()) {
+  if (SteamApps() == nullptr) {
     if (!SteamAPI_Init()) {
-      log(("noSteamApi. Path: " + hdPath.string() +
-           " Steam Path: " + steamPath.string())
-              .c_str());
+      log("noSteamApi. Path: " + hdPath.string() +
+          " Steam Path: " + steamPath.string());
       this->ui->label->setText(translation["noSteamApi"]);
       dialog = new Dialog(this, translation["noSteamApi"],
                           translation["errorTitle"]);
     } else {
-      log(("noSteamApi. Path: " + hdPath.string() +
-           " Steam Path: " + steamPath.string())
-              .c_str());
+      log("noSteamApi. Path: " + hdPath.string() +
+          " Steam Path: " + steamPath.string());
       this->ui->label->setText(translation["noSteam"]);
       dialog =
           new Dialog(this, translation["noSteam"], translation["errorTitle"]);
@@ -504,9 +502,8 @@ bool MainWindow::checkSteamApi() {
     SteamAPI_Shutdown();
     return true;
   } else {
-    log(("noSteamApi. Path: " + hdPath.string() +
-         " Steam Path: " + steamPath.string())
-            .c_str());
+    log("noSteamApi. Path: " + hdPath.string() +
+        " Steam Path: " + steamPath.string());
     this->ui->label->setText(translation["noFE"]);
     dialog = new Dialog(this, translation["noFE"], translation["errorTitle"]);
     dialog->exec();
@@ -578,7 +575,7 @@ void MainWindow::changeModPatch() {
 
   std::string dlcExtension = dlcLevel == 3 ? "" : dlcLevel == 2 ? " AK" : " FE";
   modName += std::get<0>(dataModList[patch]);
-  if (std::get<3>(dataModList[patch]) & 1) {
+  if ((std::get<3>(dataModList[patch]) & 1) != 0) {
     modName += dlcExtension;
   }
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -241,8 +241,8 @@ void MainWindow::runConverter() {
     settings.addDrsResources(modOverrideDir);
   }
 
-  QThread* thread = new QThread;
-  WKInstaller* installer = new WKInstaller(settings);
+  auto* thread = new QThread;
+  auto* installer = new WKInstaller(settings);
   installer->moveToThread(thread);
   connect(installer, SIGNAL(log(std::string)), this, SLOT(log(std::string)));
   connect(installer, SIGNAL(setInfo(std::string)), this,
@@ -309,7 +309,7 @@ void MainWindow::setProgress(int i) {
   if (i < 0)
     i = 0;
   else if (i >= 100) {
-    this->ui->centralWidget->setDisabled(false);  	
+    this->ui->centralWidget->setDisabled(false);
     logFile.close();
     i = 100;
   }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -27,8 +27,8 @@ public slots:
   QString translate(QString line);
 
 public:
-  explicit MainWindow(QWidget* parent = 0, bool skipUpdater = false);
-  ~MainWindow();
+  explicit MainWindow(QWidget* parent = nullptr, bool skipUpdater = false);
+  ~MainWindow() override;
 
 private:
   fs::path steamPath;

--- a/paths.cpp
+++ b/paths.cpp
@@ -1,11 +1,11 @@
 #include "paths.h"
 #include "libwololokingdoms/platform.h"
 #include "libwololokingdoms/string_helpers.h"
+#include <cstdio>
 #include <fs.h>
 #include <fstream>
 #include <iostream>
 #include <stdexcept>
-#include <stdio.h>
 #include <steam/steam_api.h>
 #include <string>
 

--- a/paths_linux.cpp
+++ b/paths_linux.cpp
@@ -3,13 +3,13 @@
 #include "libwololokingdoms/string_helpers.h"
 #include "paths.h"
 #include <QProcess>
-#include <errno.h>
+#include <cerrno>
+#include <cstdio>
 #include <fs.h>
 #include <fstream>
 #include <iconv.h>
 #include <iostream>
 #include <pwd.h>
-#include <stdio.h>
 #include <string>
 
 fs::path getExePath() { return fs::read_symlink("/proc/self/exe"); }

--- a/wkinstaller.cpp
+++ b/wkinstaller.cpp
@@ -22,11 +22,11 @@ void WKInstaller::process() {
   }
 }
 
-void WKInstaller::error(std::exception const& err, bool showDialog) { 
+void WKInstaller::error(std::exception const& err, bool showDialog) {
   std::string errorMessage = err.what();
   if (showDialog)
-	emit createDialog("dialogError$" + errorMessage, "Error");
-  emit log(errorMessage); 
+    emit createDialog("dialogError$" + errorMessage, "Error");
+  emit log(errorMessage);
 }
 
 void WKInstaller::installUserPatch(fs::path exePath,


### PR DESCRIPTION
(This PR doesn't need a release, it's just tweaks.)

It applies fixes using clang-tidy, which auto-upgraded a lot of the manual iterator usage to ranged for loops, reduced some unnecessary copies, and updated the code to follow some best practices.

There's also a manual fix for a memory leak that could happen if character encoding conversion failed (so it's rare and not high prio)

An interesting bit is the WKConverter methods that were autofixed to be static methods because they didn't use `this`; they could become testable freestanding functions in the future…

Sneaking in some performance improvements:
<details>
<summary>Reduce large copies of HD dat file structures</summary>

Previously, we'd read the `aocDat` and `hdDat` structures, then do a lot
of assignments to `aocDat`. This required:
- Destroying all of the structures in `aocDat`
- Copying all the data from `hdDat` (copy constructing)
- Destroying all of the structures in `hdDat`

Which would add up to a significant amount of work.

With std::move, we now only:
- Destroy all of the structures in `aocDat`
- Change the pointers in `aocDat` to point to `hdDat` and clear the
pointers in `hdDat` (super cheap)

Eventually `hdDat` is also destroyed but it only requires destructing
the small amount of data it still holds.

In my unscientific test, with the old method `transferHdDatElements`
took about 5% of install time. Now, it takes about 1%.
</details>
<details>
<summary>Make parseHDTextLine noexcept</summary>

80+% of the time in parseHDTextLine was spent on exception handling. This change
returns an `optional<>` because we don't care about the type of
exception anyway, and optionals are very very cheap. Instead of relying
on stoi to throw an exception, it checks if a given string key is
all digits and then uses the C-style, exception-less `atoi` function.
</details>
<details>
<summary>Use compile-time regex library + manual find()s instead of std::regex in places</summary>

`isTerrainUsed()` and `usesMultipleWaterTerrains()` now barely take any time anymore because they use CTRE for hardcoded regexes, which generates very efficient regex matching code at compile time. Those regexes are all differently typed, so the "default" case where the regex was taken from a `std::map` now uses `string.find()` instead which is a lot quicker.

</details>

The shasum of the generated dat file is the same before and after this PR.

## Things that need to be checked
- [x] The regex changes cause small differences in the converted maps. For example, rw_eastafrica.rms changes like:
     ```diff
     - #const MYSAVANNAH 6
     - #const MYDIRT4 24
     + #const MYSAVANNAH 0
     + #const MYDIRT4 6
     ```
     And i'm not sure if that's correct.